### PR TITLE
Loot Spawn

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -254,6 +254,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scenes/objects/pickable_items/equipment/tool/light-sources/lanterns.gd"
 }, {
+"base": "Resource",
+"class": "LootSpawnList",
+"language": "GDScript",
+"path": "res://scenes/worlds/procedural_world/loot_spawn_list.gd"
+}, {
 "base": "AStar2D",
 "class": "ManhattanAStar2D",
 "language": "GDScript",
@@ -419,6 +424,7 @@ _global_script_class_icons={
 "Interactable": "",
 "KeyItem": "",
 "LanternItem": "",
+"LootSpawnList": "",
 "ManhattanAStar2D": "",
 "MeleeItem": "",
 "MeshTransform": "",

--- a/scenes/characters/player/player_hit.gd
+++ b/scenes/characters/player/player_hit.gd
@@ -1,28 +1,39 @@
 extends CanvasLayer
 
 
-onready var opacity_target = [0.1, 0.2]
 var tween_speed = 0.7
 var is_fade_in = false
+
+onready var opacity_target = [0.1, 0.2]
+onready var debug_label: RichTextLabel = $RichTextLabel
+onready var keybind_defaults: RichTextLabel = $KeybindDefaults
+onready var color_rect: TextureRect = $ColorRect
+onready var texture_rect: TextureRect = $TextureRect
+onready var animation_player: AnimationPlayer = $AnimationPlayer
+onready var tween: Tween = $Tween
 
 #------>FOR TESTING<------
 var health = 100 
 
 
 func _process(delta):
-	$RichTextLabel.text = (" player light_level = " + str(owner.light_level) + " \nplayer on floor = " + 
-		str(owner.is_on_floor()))
+	var player := owner as Player
+	debug_label.text = (
+		"player light_level = " + str(player.light_level) + "\n"
+		+ "player on floor = " +  str(player.is_on_floor()) + "\n"
+		+ "player position = " +  str(player.translation) + "\n"
+	)
 
 
 func _input(event):
 	if event is InputEvent and event.is_action_pressed("help_info"):
-		$KeybindDefaults.visible = !$KeybindDefaults.visible
+		keybind_defaults.visible = !keybind_defaults.visible
 #	if event is InputEvent and event.is_action_pressed("kick"):
-#		if not $ColorRect.is_visible_in_tree():
-#			$ColorRect.show()
-#		if $AnimationPlayer.is_playing():
-#			$AnimationPlayer.stop()
-#		$AnimationPlayer.play("hit_effect")
+#		if not color_rect.is_visible_in_tree():
+#			color_rect.show()
+#		if animation_player.is_playing():
+#			animation_player.stop()
+#		animation_player.play("hit_effect")
 #
 #		health -= 5
 #
@@ -51,9 +62,9 @@ func _input(event):
 #			opacity_target[0] = 0.1
 #			opacity_target[1] = 0.3
 #		elif health <= 40:
-#			if not $TextureRect.is_visible_in_tree():
-#				$TextureRect.show()
-#			if not $Tween.is_active() and not $Tween.is_active():
+#			if not texture_rect.is_visible_in_tree():
+#				texture_rect.show()
+#			if not tween.is_active() and not tween.is_active():
 #				_start_fade_in()
 #			opacity_target[0] = 0.05
 #			opacity_target[1] = 0.2
@@ -61,12 +72,12 @@ func _input(event):
 
 
 func _on_Player_is_hit(current_health):
-	if not $ColorRect.is_visible_in_tree():
-		$ColorRect.show()
+	if not color_rect.is_visible_in_tree():
+		color_rect.show()
 	
-	if $AnimationPlayer.is_playing():
-		$AnimationPlayer.stop()
-	$AnimationPlayer.play("hit_effect")
+	if animation_player.is_playing():
+		animation_player.stop()
+	animation_player.play("hit_effect")
 	
 	if current_health <= 5:
 		opacity_target[0] = 0.7
@@ -93,10 +104,10 @@ func _on_Player_is_hit(current_health):
 		opacity_target[0] = 0.1
 		opacity_target[1] = 0.3
 	elif current_health <= 40:
-		if not $TextureRect.is_visible_in_tree():
-			$TextureRect.show()
+		if not texture_rect.is_visible_in_tree():
+			texture_rect.show()
 		
-		if not $Tween.is_active() and not $Tween.is_active():
+		if not tween.is_active() and not tween.is_active():
 			_start_fade_in()
 		opacity_target[0] = 0.05
 		opacity_target[1] = 0.2
@@ -104,16 +115,16 @@ func _on_Player_is_hit(current_health):
 
 func _start_fade_in():
 	is_fade_in = true
-	$Tween.interpolate_property($TextureRect, "modulate", 
+	tween.interpolate_property(texture_rect, "modulate", 
 			Color(1, 1, 1, opacity_target[0]), Color(1, 1, 1, opacity_target[1]), tween_speed, Tween.TRANS_SINE, Tween.EASE_OUT)    
-	$Tween.start()
+	tween.start()
 
 
 func _start_fade_out():
 	is_fade_in = false
-	$Tween.interpolate_property($TextureRect, "modulate", 
+	tween.interpolate_property(texture_rect, "modulate", 
 			Color(1, 1, 1, opacity_target[1]), Color(1, 1, 1, opacity_target[0]), tween_speed, Tween.TRANS_SINE, Tween.EASE_IN)    
-	$Tween.start()
+	tween.start()
 
 
 func _on_Tween_tween_completed(object, key):
@@ -124,5 +135,5 @@ func _on_Tween_tween_completed(object, key):
 
 
 func _on_Player_character_died():
-	$TextureRect.hide()
-	$ColorRect.hide()
+	texture_rect.hide()
+	color_rect.hide()

--- a/scenes/worlds/procedural_world/intial_loot_list.tres
+++ b/scenes/worlds/procedural_world/intial_loot_list.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://scenes/worlds/procedural_world/loot_spawn_list.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+_paths = [ "res://scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.tscn", "res://scenes/objects/pickable_items/equipment/consumable/disposable_lights/torch/torch.tscn", "res://scenes/objects/pickable_items/equipment/tool/light-sources/candlestick/candlestick.tscn", "res://scenes/objects/pickable_items/equipment/tool/light-sources/candelabra/candelabra.tscn", "res://scenes/objects/pickable_items/equipment/tool/light-sources/candle_lantern/candle_lantern.tscn", "res://scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn", "res://scenes/objects/pickable_items/equipment/tool/light-sources/bullseye_lantern/bullseye_lantern.tscn", "res://scenes/objects/pickable_items/equipment/ranged/webley_revolver/webley.tscn", "res://scenes/objects/pickable_items/tiny/ammo/webley/webley_box.tscn", "res://scenes/objects/pickable_items/tiny/ammo/webley/webley_round.tscn", "res://scenes/objects/pickable_items/equipment/ranged/double-barrel_sawed_shotgun/shotgun_sawed_item.tscn", "res://scenes/objects/pickable_items/equipment/ranged/double-barrel_shotgun/shotgun_item.tscn", "res://scenes/objects/pickable_items/tiny/ammo/shotgun_shells/12-gauge_box.tscn", "res://scenes/objects/pickable_items/equipment/ranged/martini_henry_rifle/martini_henry_rifle.tscn", "res://scenes/objects/pickable_items/tiny/ammo/martini-henry/martini-henry_box.tscn", "res://scenes/objects/pickable_items/tiny/ammo/martini-henry/martini-henry_round.tscn", "res://scenes/objects/pickable_items/equipment/consumable/bomb/dynamite/dynamite.tscn", "res://scenes/objects/pickable_items/equipment/consumable/bomb/grenade/grenade.tscn" ]
+_weights = [ 1000, 250, 100, 50, 25, 10, 5, 5, 5, 50, 10, 20, 5, 20, 5, 20, 5, 1 ]
+_min_amounts = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+_max_amounts = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 5, 1, 1, 1, 1, 1, 5, 1, 1 ]

--- a/scenes/worlds/procedural_world/item_spawner.gd
+++ b/scenes/worlds/procedural_world/item_spawner.gd
@@ -11,60 +11,50 @@ export var starting_light: PackedScene
 
 var free_cell = 0
 
+var _used_cell_indexes := []
 
-func get_next_free_cell(data : WorldData) -> bool:
+### Private Methods --------------------------------------------------------------------------------
+
+func _on_ProceduralWorld_generation_finished() -> void:
+	var data := owner.world_data as WorldData
+	_spawn_starting_light(data)
+	_spawn_initial_settings_items(data)
+
+
+func _spawn_initial_settings_items(data : WorldData):
+	var settings : SettingsClass = GameManager.game.local_settings
+	
+	_get_next_free_cell(data)
+	for s in settings.get_settings_list():
+		var g = settings.get_setting_group(s)
+		var amount = settings.get_setting(s)
+		
+		if g == "Equipment":
+			for i in amount:
+				if not _get_next_free_cell(data):
+					return
+				
+				_used_cell_indexes.append(free_cell)
+				var cell_pos = data.get_local_cell_position(free_cell)
+				_spawn_item(s, cell_pos)
+		elif g == "Tiny Items":
+			if amount == 0:
+				continue
+			if not _get_next_free_cell(data):
+				return
+			
+			_used_cell_indexes.append(free_cell)
+			var pos = data.get_local_cell_position(free_cell) + ITEM_POSITION_OFFSET
+			_spawn_tiny_item(s, amount, pos)
+
+
+func _get_next_free_cell(data : WorldData) -> bool:
 	free_cell += 1
 	while data.get_cell_type(free_cell) == data.CellType.EMPTY and free_cell < data.cell_count:
 		free_cell += 1
 	return true
 	if free_cell >= data.cell_count:
 		return false
-
-
-func spawn_items(data : WorldData):
-	var tiny_item_scene = preload("res://scenes/objects/pickable_items/tiny/_tiny_item.tscn")
-	var settings : SettingsClass = GameManager.game.local_settings
-	
-	_spawn_starting_light(data)
-	get_next_free_cell(data)
-	for s in settings.get_settings_list():
-		var g = settings.get_setting_group(s)
-		if g == "Equipment":
-			var amount = settings.get_setting(s)
-			for i in amount:
-				if not get_next_free_cell(data):
-					return
-				var cell_pos = data.get_local_cell_position(free_cell)
-				_spawn_item(s, cell_pos)
-		elif g == "Tiny Items":
-			var amount = settings.get_setting(s)
-			if amount == 0:
-				continue
-			if not get_next_free_cell(data):
-				return
-			var pos = data.get_local_cell_position(free_cell) + ITEM_POSITION_OFFSET
-			var item : TinyItem = tiny_item_scene.instance()
-			item.amount = amount
-			item.item_data = load(s)
-			item.translation = pos
-			owner.add_child(item)
-			pass
-
-
-func _spawn_starting_light(data : WorldData) -> void:
-	if starting_light == null:
-		return
-	
-	var starting_cells = data.get_cells_for(data.CellType.STARTING_ROOM)
-	if data.is_spawn_position_valid():
-		var player_index := data.get_player_spawn_position_as_index()
-		starting_cells.erase(player_index)
-	
-	var random_cell_index := randi() % starting_cells.size() as int
-	var spawn_cell = starting_cells[random_cell_index]
-	print("light spawned at: %s"%[data.get_int_position_from_cell_index(spawn_cell)])
-	var local_pos = data.get_local_cell_position(spawn_cell)
-	_spawn_item(starting_light.resource_path, local_pos)
 
 
 func _spawn_item(scene_path: String, cell_pos: Vector3) -> void:
@@ -78,6 +68,30 @@ func _spawn_item(scene_path: String, cell_pos: Vector3) -> void:
 	owner.add_child(item)
 
 
-func _on_ProceduralWorld_generation_finished() -> void:
-	spawn_items(owner.world_data)
-	pass # Replace with function body.
+func _spawn_tiny_item(item_data_path: String, amount: int, position: Vector3) -> void:
+	var tiny_item_scene = preload("res://scenes/objects/pickable_items/tiny/_tiny_item.tscn")
+	var item : TinyItem = tiny_item_scene.instance()
+	item.amount = amount
+	item.item_data = load(item_data_path)
+	item.translation = position
+	owner.add_child(item)
+
+
+func _spawn_starting_light(data : WorldData) -> void:
+	if starting_light == null:
+		return
+	
+	var starting_cells = data.get_cells_for(data.CellType.STARTING_ROOM)
+	if data.is_spawn_position_valid():
+		var player_index := data.get_player_spawn_position_as_index()
+		starting_cells.erase(player_index)
+	
+	var random_cell_index := randi() % starting_cells.size() as int
+	var spawn_cell = starting_cells[random_cell_index]
+	_used_cell_indexes.append(spawn_cell)
+	print("light spawned at: %s"%[data.get_int_position_from_cell_index(spawn_cell)])
+	
+	var local_pos = data.get_local_cell_position(spawn_cell)
+	_spawn_item(starting_light.resource_path, local_pos)
+
+### ------------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/item_spawner.gd
+++ b/scenes/worlds/procedural_world/item_spawner.gd
@@ -1,4 +1,8 @@
+tool
 extends Node
+
+# This is a tool so that `_min_loot` and `_max_loot` setters can act as data validators when
+# changing values in the editor
 
 const ITEM_POSITION_OFFSET = Vector3(0.75, 1.0, 0.75)
 
@@ -11,14 +15,60 @@ export var starting_light: PackedScene
 
 var free_cell = 0
 
+export var _loot_list_resource: Resource = null
+export var _min_loot := 5 setget _set_min_loot
+export var _max_loot := 8 setget _set_max_loot
+
+var _rng := RandomNumberGenerator.new()
 var _used_cell_indexes := []
 
-### Private Methods --------------------------------------------------------------------------------
+
+### Built in Engine Methods -----------------------------------------------------------------------
+
+func _ready() -> void:
+	if Engine.editor_hint:
+		return
+	
+	_rng.randomize()
+
+### -----------------------------------------------------------------------------------------------
+
+### Private Methods -------------------------------------------------------------------------------
 
 func _on_ProceduralWorld_generation_finished() -> void:
 	var data := owner.world_data as WorldData
 	_spawn_starting_light(data)
 	_spawn_initial_settings_items(data)
+	_spawn_initial_loot(data)
+
+
+func _spawn_initial_loot(data : WorldData) -> void:
+	var loot_list := _loot_list_resource as LootSpawnList
+	var draw_amount := _rng.randi_range(_min_loot, _max_loot)
+	var possible_cells := data.get_cells_for(data.CellType.ROOM)
+	possible_cells = _remove_used_cells(possible_cells)
+	
+	for _i in draw_amount:
+		var loot_data := loot_list.draw_random_loot()
+		if possible_cells.empty():
+			return
+		
+		var lucky_index = randi() % possible_cells.size()
+		var cell_index := possible_cells[lucky_index] as int
+		_used_cell_indexes.append(cell_index)
+		possible_cells.remove(cell_index)
+		
+		var position := data.get_local_cell_position(cell_index) + ITEM_POSITION_OFFSET
+		for _loot_i in loot_data.amount:
+			_spawn_item(loot_data.scene_path, position)
+			print("item spawned: %s | at: %s"%[loot_data.scene_path, position])
+
+
+func _remove_used_cells(p_array: Array) -> Array:
+	for cell_index in _used_cell_indexes:
+		p_array.erase(cell_index)
+	
+	return p_array
 
 
 func _spawn_initial_settings_items(data : WorldData):
@@ -35,7 +85,7 @@ func _spawn_initial_settings_items(data : WorldData):
 					return
 				
 				_used_cell_indexes.append(free_cell)
-				var cell_pos = data.get_local_cell_position(free_cell)
+				var cell_pos = data.get_local_cell_position(free_cell) + ITEM_POSITION_OFFSET
 				_spawn_item(s, cell_pos)
 		elif g == "Tiny Items":
 			if amount == 0:
@@ -57,13 +107,11 @@ func _get_next_free_cell(data : WorldData) -> bool:
 		return false
 
 
-func _spawn_item(scene_path: String, cell_pos: Vector3) -> void:
-	var pos = cell_pos + ITEM_POSITION_OFFSET
-	
+func _spawn_item(scene_path: String, position: Vector3) -> void:
 	var item
 	var item_scene : PackedScene = load(scene_path)
 	item = item_scene.instance()
-	(item as Spatial).translation = pos
+	(item as Spatial).translation = position
 	
 	owner.add_child(item)
 
@@ -91,7 +139,15 @@ func _spawn_starting_light(data : WorldData) -> void:
 	_used_cell_indexes.append(spawn_cell)
 	print("light spawned at: %s"%[data.get_int_position_from_cell_index(spawn_cell)])
 	
-	var local_pos = data.get_local_cell_position(spawn_cell)
+	var local_pos = data.get_local_cell_position(spawn_cell) + ITEM_POSITION_OFFSET
 	_spawn_item(starting_light.resource_path, local_pos)
 
-### ------------------------------------------------------------------------------------------------
+
+func _set_min_loot(value: int) -> void:
+	_min_loot = clamp(value, 0, _max_loot)
+
+
+func _set_max_loot(value: int) -> void:
+	_max_loot = max(value, _min_loot)
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/loot_spawn_list.gd
+++ b/scenes/worlds/procedural_world/loot_spawn_list.gd
@@ -1,0 +1,158 @@
+tool
+class_name LootSpawnList
+extends Resource
+
+var _paths := []
+var _weights := []
+var _min_amounts := []
+var _max_amounts := []
+
+###################################################################################################
+# Editor Methods ##################################################################################
+###################################################################################################
+
+const LOOT_PREFIX = "loot_"
+
+### Custom Inspector built in functions -----------------------------------------------------------
+
+func _get_property_list() -> Array:
+	var properties: = []
+	
+	properties.append({
+		name = "_paths",
+		type = TYPE_ARRAY,
+		usage = PROPERTY_USAGE_STORAGE,
+	})
+	
+	properties.append({
+		name = "_weights",
+		type = TYPE_ARRAY,
+		usage = PROPERTY_USAGE_STORAGE,
+	})
+	
+	properties.append({
+		name = "_min_amounts",
+		type = TYPE_ARRAY,
+		usage = PROPERTY_USAGE_STORAGE,
+	})
+	
+	properties.append({
+		name = "_max_amounts",
+		type = TYPE_ARRAY,
+		usage = PROPERTY_USAGE_STORAGE,
+	})
+	
+	properties.append({
+		name = "total_items",
+		type = TYPE_INT,
+		usage = PROPERTY_USAGE_EDITOR,
+		hint = PROPERTY_HINT_RANGE,
+		hint_string = "0,1,1,or_greater"
+	})
+	
+	for index in _paths.size():
+		var group_name = LOOT_PREFIX + str(index)
+		properties.append({
+			name = group_name,
+			type = TYPE_NIL,
+			usage = PROPERTY_USAGE_GROUP,
+			hint_string = "%s_"%[group_name]
+		})
+		
+		properties.append({
+			name = "%s_%s"%[group_name, "scene_path"],
+			type = TYPE_STRING,
+			usage = PROPERTY_USAGE_EDITOR,
+			hint = PROPERTY_HINT_FILE,
+			hint_string = "*.tscn"
+		})
+		
+		properties.append({
+			name = "%s_%s"%[group_name, "weight"],
+			type = TYPE_INT,
+			usage = PROPERTY_USAGE_EDITOR,
+			hint = PROPERTY_HINT_RANGE,
+			hint_string = "1,2,1,or_greater"
+		})
+		
+		properties.append({
+			name = "%s_%s"%[group_name, "min_amount"],
+			type = TYPE_INT,
+			usage = PROPERTY_USAGE_EDITOR,
+			hint = PROPERTY_HINT_RANGE,
+			hint_string = "1,2,1,or_greater"
+		})
+		
+		properties.append({
+			name = "%s_%s"%[group_name, "max_amount"],
+			type = TYPE_INT,
+			usage = PROPERTY_USAGE_EDITOR,
+			hint = PROPERTY_HINT_RANGE,
+			hint_string = "1,2,1,or_greater"
+		})
+		
+	
+	return properties
+
+
+func _get(property: String):
+	var value
+	
+	if property == "total_items":
+		value = _paths.size()
+	elif property.begins_with(LOOT_PREFIX):
+		var prop_data := property.replace(LOOT_PREFIX, "").split("_", false, 1) as PoolStringArray
+		var index := (prop_data[0] as String).to_int()
+		var key := prop_data[1] as String
+		match key:
+			"scene_path":
+				if _paths[index] == null:
+					_paths[index] = ""
+				value = _paths[index]
+			"weight":
+				if _weights[index] == null:
+					_weights[index] = 1
+				value = _weights[index]
+			"min_amount":
+				if _min_amounts[index] == null:
+					_min_amounts[index] = 1
+				value = _min_amounts[index]
+			"max_amount":
+				if _max_amounts[index] == null:
+					_max_amounts[index] = 1
+				value = _max_amounts[index]
+			_:
+				push_error("Unrecognized loot property key: %s"%[key])
+	
+	return value
+
+
+func _set(property: String, value) -> bool:
+	var has_handled: = true
+	
+	if property == "total_items":
+		for item in [_paths, _weights, _min_amounts, _max_amounts]:
+			var array := item as Array
+			array.resize(value)
+			property_list_changed_notify()
+	elif property.begins_with(LOOT_PREFIX):
+		var prop_data := property.replace(LOOT_PREFIX, "").split("_", false, 1) as PoolStringArray
+		var index := (prop_data[0] as String).to_int()
+		var key := prop_data[1] as String
+		match key:
+			"scene_path":
+				_paths[index] = value
+			"weight":
+				_weights[index] = value
+			"min_amount":
+				_min_amounts[index] = value
+			"max_amount":
+				_max_amounts[index] = value
+			_:
+				push_error("Unrecognized loot property key: %s"%[key])
+	else:
+		has_handled = false
+	
+	return has_handled
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/loot_spawn_list.gd
+++ b/scenes/worlds/procedural_world/loot_spawn_list.gd
@@ -7,6 +7,78 @@ var _weights := []
 var _min_amounts := []
 var _max_amounts := []
 
+var _current_paths := []
+var _current_weights := []
+var _current_min_amounts := []
+var _current_max_amounts := []
+
+var _current_total_weight := 0
+
+var _rng: RandomNumberGenerator = null
+
+### Public Methods --------------------------------------------------------------------------------
+
+func draw_random_loot() -> LootData:
+	var loot_data: LootData = LootData.new()
+	
+	if _current_paths.empty():
+		_initialize_current_arrays()
+	
+	var random_value = randi() % _current_total_weight
+	var index := 0
+	for value in _current_weights:
+		var weight := value as int
+		if random_value < weight:
+			break
+		else:
+			random_value -= weight
+			index += 1
+	
+	loot_data.scene_path = _current_paths[index]
+	loot_data.amount = _rng.randi_range(_current_min_amounts[index], _current_max_amounts[index])
+	
+	_exclude_used_index(index)
+	_current_total_weight = _calculate_total_weight()
+	
+	return loot_data
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+func _initialize_current_arrays() -> void:
+	_current_paths = _paths.duplicate()
+	_current_weights = _weights.duplicate()
+	_current_min_amounts = _min_amounts.duplicate()
+	_current_max_amounts = _max_amounts.duplicate()
+	_rng = RandomNumberGenerator.new()
+	_rng.randomize()
+	
+	_current_total_weight = _calculate_total_weight()
+
+
+func _exclude_used_index(p_index: int) -> void:
+	_current_paths.remove(p_index)
+	_current_weights.remove(p_index)
+	_current_min_amounts.remove(p_index)
+	_current_max_amounts.remove(p_index)
+
+
+func _calculate_total_weight() -> int:
+	var value := 0
+	
+	for weight in _current_weights:
+		value += weight
+	
+	return value
+
+### -----------------------------------------------------------------------------------------------
+
+class LootData extends Reference:
+	var scene_path: String = ""
+	var amount: int = 0
+
 ###################################################################################################
 # Editor Methods ##################################################################################
 ###################################################################################################

--- a/scenes/worlds/procedural_world/procedural_world.tscn
+++ b/scenes/worlds/procedural_world/procedural_world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://scenes/worlds/game_world.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/worlds/procedural_world/procedural_world.gd" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://resources/mesh_libraries/modular_pieces.meshlib" type="MeshLibrary" id=5]
 [ext_resource path="res://scenes/characters/cultists/neophyte.tscn" type="PackedScene" id=6]
 [ext_resource path="res://scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn" type="PackedScene" id=7]
+[ext_resource path="res://scenes/worlds/procedural_world/intial_loot_list.tres" type="Resource" id=8]
 [ext_resource path="res://scenes/worlds/procedural_world/character_spawner.gd" type="Script" id=9]
 [ext_resource path="res://scenes/worlds/procedural_world/item_spawner.gd" type="Script" id=16]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_rooms.gd" type="Script" id=17]
@@ -84,6 +85,7 @@ pillar_tile = 16
 [node name="ItemSpawner" type="Node" parent="." index="7"]
 script = ExtResource( 16 )
 starting_light = ExtResource( 7 )
+_loot_list_resource = ExtResource( 8 )
 
 [connection signal="generation_finished" from="." to="EnemySpawner" method="_on_ProceduralWorld_generation_finished"]
 [connection signal="generation_finished" from="." to="ItemSpawner" method="_on_ProceduralWorld_generation_finished"]


### PR DESCRIPTION
Closes #406 

Implemented mostly as described in #406 
Known issues:
- Ammo rounds seem to fall forever, but I don't think it's related to this feature, so it will probably be faster if someone familiar with them looks into it.
- Some items in the description of the issue were not found (https://github.com/Mooses2k/SecretHistories/issues/406#issuecomment-1562871508), but see below how to add them later.

This PR adds a `LootSpawnList` custom resource, and the file `initial_loot_list.tres` holds the list with the same values as in the issue description. To add more items to it, just increase `total_items` and fill in the fields, or just change existing fields to tweak the values for any item.

https://github.com/Mooses2k/SecretHistories/assets/13070158/6a695118-0be9-4049-9945-3d79116f3563

`LootSpawnList` will take care of the weighted draw logic, and doesn't draw repeated items were drawn, then it resets the list. It will draw repeated items if they're registered more than once in the Loot list. It also can be saved as external resources so that we can have different lists of lot and swap them easily. This could also be used to draw loot according to item categories, by just creating more resources where loot is listed by category and adjusting item spawner to draw from each list separately.

Then `item_spanwer.gd` was changed, it now has an export var for the loot list and will draw a random number of items from that list. This is configurable on the editor:
![image](https://github.com/Mooses2k/SecretHistories/assets/13070158/0d5dff95-55c3-43c8-9f88-7271ae3c5677)

I didn't remove the initial settings spawn, I just left it as is and created a new function so that the different kind of spawns can easily be toggled on/off or replaced:
![image](https://github.com/Mooses2k/SecretHistories/assets/13070158/5e9ba1c7-6e0c-4ddb-b277-d34d0a559aa7)

For now there are some print messages to say where each item was spawned, I used that to check if it was working, but they can be silenced later, this also helped find out that ammo rounds are being spawned on valid coordinates (apparently), but are falling forever. This only happens with ammo rounds, not ammo boxes or other loot.

Also changed `player_hit.gd` debug label to show the current player position, this made it easier to find the position of the spawned items by checking where the prints with their locations and going there.
![image](https://github.com/Mooses2k/SecretHistories/assets/13070158/c9c589f1-afcc-4f3d-8001-ccefcdedf462)
