### PR TITLE
Voices, stealth, sensors, noise, fix 2 regressions

### DIFF
--- a/core/ai/action_nodes/bt_go_to_target.gd
+++ b/core/ai/action_nodes/bt_go_to_target.gd
@@ -2,8 +2,12 @@ class_name BT_Go_To_Target
 extends BT_Node
 
 
+signal plans_to_approach
+
 export var threshold : float = 0.5 setget set_threshold
 var _thresold_squared : float = 0.25
+
+export var speed = 2.0
 
 
 func set_threshold(value : float):
@@ -19,6 +23,8 @@ func tick(state : CharacterState) -> int:
 
 	while state.path.size() > 0 and state.path[0].distance_squared_to(character.global_transform.origin) <= threshold:
 		state.path.pop_front()
+		emit_signal("plans_to_approach")
+		character.move_speed = speed
 
 	if state.path.size() > 0:
 		state.move_direction = state.path[0] - character.global_transform.origin

--- a/core/ai/action_nodes/bt_reload_gun.gd
+++ b/core/ai/action_nodes/bt_reload_gun.gd
@@ -2,12 +2,15 @@ class_name BT_Reload_Gun
 extends BT_Node
 
 
+signal character_reloaded
+
 func tick(state : CharacterState) -> int:
 	var equipment = state.character.inventory.current_mainhand_equipment as GunItem
 	print(equipment)
 	if equipment:
 		print("Cultist reloading")
 		equipment.reload()
+		emit_signal("character_reloaded")
 		return Status.SUCCESS
 	print("Cultist didn't reload successfully?")
 	return Status.FAILURE

--- a/core/ai/action_nodes/bt_wait_random.gd
+++ b/core/ai/action_nodes/bt_wait_random.gd
@@ -2,7 +2,7 @@ class_name BT_Wait_Random
 extends BT_Node
 
 
-signal cultist_idled
+signal character_idled
 
 export var max_time : float = 2.0
 export var min_time : float = 1.0
@@ -38,7 +38,7 @@ func tick(state : CharacterState) -> int:
 func reset_timer():
 	var speech_chance = randf()
 	if (speech_chance > 0.95):
-		emit_signal("cultist_idled")
+		emit_signal("character_idled")
 		print("Idle speech signalled")
 	time_left = rand_range(min_time, max_time)
 	reset = true

--- a/core/ai/check_nodes/bt_inventory_has_ammo.gd
+++ b/core/ai/check_nodes/bt_inventory_has_ammo.gd
@@ -9,6 +9,6 @@ func tick(state : CharacterState) -> int:
 		for ammo_type in equipment.ammo_types:
 #			if inventory.tiny_items.has(ammo_type) and inventory.tiny_items[ammo_type] > 0:
 #				print("Cultist's inventory has relevant ammo: ", inventory.tiny_items[ammo_type])
-			return Status.FAILURE # fails because this is a selector, fail means check next item
+			return Status.FAILURE   # Fails because this is a selector, fail means check next item
 #		return Status.RUNNING
 	return Status.SUCCESS

--- a/core/ai/check_nodes/bt_player_sensor.gd
+++ b/core/ai/check_nodes/bt_player_sensor.gd
@@ -2,6 +2,8 @@ class_name BT_Player_Sensor
 extends BT_Node
 
 
+signal character_detected
+
 export var sensor : NodePath
 onready var _sensor : PlayerSensor = get_node(sensor) as PlayerSensor
 
@@ -10,4 +12,5 @@ func tick(state : CharacterState) -> int:
 	if _sensor.is_player_detected():
 #		return Status.FAILURE
 		state.target_position = _sensor.get_measured_position()
+		emit_signal("character_detected")
 	return Status.SUCCESS

--- a/core/ai/check_nodes/bt_sound_listener.gd
+++ b/core/ai/check_nodes/bt_sound_listener.gd
@@ -2,14 +2,22 @@ class_name BT_Sound_Listener
 extends BT_Node
 
 
+signal unseen_sound_heard
+
+export var direct_player_sight : NodePath
+onready var _direct_player_sight : PlayerSensor = get_node(direct_player_sight) as PlayerSensor
 export var listener : NodePath
 onready var _listener : SoundListener = get_node(listener) as SoundListener
 
 
 func tick(state : CharacterState) -> int:
-	if not _listener.player_sight_sensor.is_player_detected():
+#	if not _listener.player_sight_sensor.is_player_detected():
+	if not _direct_player_sight.is_player_detected():
+		
 		if not _listener.is_sound_detected():
 			return Status.FAILURE
+		emit_signal("unseen_sound_heard")
+		print("Unseen sound heard")
 		state.target_position = _listener.get_measured_position()
 	
 	return Status.SUCCESS

--- a/project.godot
+++ b/project.godot
@@ -129,6 +129,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scenes/objects/pickable_items/equipment/tool/light-sources/candelabra/candelabra.gd"
 }, {
+"base": "ConsumableItem",
+"class": "CandleItem",
+"language": "GDScript",
+"path": "res://scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.gd"
+}, {
 "base": "KinematicBody",
 "class": "Character",
 "language": "GDScript",
@@ -188,6 +193,11 @@ _global_script_classes=[ {
 "class": "Effect",
 "language": "GDScript",
 "path": "res://scenes/effects/effects.gd"
+}, {
+"base": "EquipmentItem",
+"class": "EmptyHand",
+"language": "GDScript",
+"path": "res://scenes/objects/pickable_items/equipment/empty_slot/empty_hand.gd"
 }, {
 "base": "PickableItem",
 "class": "EquipmentItem",
@@ -359,6 +369,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scenes/objects/pickable_items/equipment/tool/tool_item.gd"
 }, {
+"base": "ConsumableItem",
+"class": "TorchItem",
+"language": "GDScript",
+"path": "res://scenes/objects/pickable_items/equipment/consumable/disposable_lights/torch/torch.gd"
+}, {
 "base": "MeshInstance",
 "class": "VisibilityMask",
 "language": "GDScript",
@@ -373,11 +388,6 @@ _global_script_classes=[ {
 "class": "WritingItem",
 "language": "GDScript",
 "path": "res://scenes/objects/pickable_items/equipment/writing/writing_item.gd"
-}, {
-"base": "EquipmentItem",
-"class": "empty_hand",
-"language": "GDScript",
-"path": "res://scenes/objects/pickable_items/equipment/empty_slot/empty_hand.gd"
 } ]
 _global_script_class_icons={
 "AmmunitionData": "",
@@ -404,6 +414,7 @@ _global_script_class_icons={
 "BombItem": "",
 "BoxOutlineMesh": "",
 "CandelabraItem": "",
+"CandleItem": "",
 "Character": "",
 "CharacterAudio": "",
 "CharacterSpawner": "",
@@ -416,6 +427,7 @@ _global_script_class_icons={
 "Door_body": "",
 "Dynamite": "",
 "Effect": "",
+"EmptyHand": "",
 "EquipmentItem": "",
 "Game": "",
 "GameWorld": "",
@@ -450,10 +462,10 @@ _global_script_class_icons={
 "TinyItem": "",
 "TinyItemData": "",
 "ToolItem": "",
+"TorchItem": "",
 "VisibilityMask": "",
 "WorldData": "",
-"WritingItem": "",
-"empty_hand": ""
+"WritingItem": ""
 }
 
 [application]

--- a/resources/world/world_data.gd
+++ b/resources/world/world_data.gd
@@ -528,11 +528,11 @@ func set_wall_meta(cell_index : int, direction : int, value = null):
 
 
 func get_wall_tile_index(cell_index : int, direction : int) -> int:
-	return wall_tile_index[4*cell_index + direction]
+	return wall_tile_index[4 * cell_index + direction]
 
 
 func set_wall_tile_index(cell_index : int, direction : int, value : int):
-	wall_tile_index[4*cell_index + direction] = value
+	wall_tile_index[4 * cell_index + direction] = value
 
 
 func set_wall(cell_index : int, direction : int, wall_type : int = EdgeType.EMPTY, tile_index : int = -1, meta_value = null):

--- a/scenes/UI/game_intro.gd
+++ b/scenes/UI/game_intro.gd
@@ -8,7 +8,7 @@ func _input(event):
 #	if event.is_action_pressed("fullscreen"):
 #		VideoSettings.set_fullscreen_enabled(!VideoSettings.is_fullscreen_enabled())
 		# Size the center container to screen size
-	if event.is_action_pressed("ui_cancel"):   # or event.is_action_pressed("ui_accept")
+	if event.is_action_pressed("ui_cancel") or event.is_action_pressed("ui_accept"): # But not mouse button
 		_start_game()
 		queue_free()
 

--- a/scenes/UI/game_intro.gd
+++ b/scenes/UI/game_intro.gd
@@ -8,7 +8,7 @@ func _input(event):
 #	if event.is_action_pressed("fullscreen"):
 #		VideoSettings.set_fullscreen_enabled(!VideoSettings.is_fullscreen_enabled())
 		# Size the center container to screen size
-	if event.is_action_pressed("ui_cancel") or event.is_action_pressed("ui_accept"): # But not mouse button
+	if event.is_action_pressed("ui_cancel"):
 		_start_game()
 		queue_free()
 

--- a/scenes/character_audio.gd
+++ b/scenes/character_audio.gd
@@ -209,20 +209,20 @@ func play_detection_sound():
 
 
 func play_ambush_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_ambush_sounds.shuffle()
 	speech_audio.stream = _ambush_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.AMBUSH
 	speech_audio.play()
 
 
 func play_chase_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_chase_sounds.shuffle()
 	speech_audio.stream = _chase_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.CHASE
 	speech_audio.play()
@@ -244,23 +244,23 @@ func play_fight_sound():
 
 
 func play_reload_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
 	if speech_audio.is_playing() == true:
 		return
 	_reload_sounds.shuffle()
 	speech_audio.stream = _reload_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.RELOAD
 	speech_audio.play()
 
 
 func play_flee_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_flee_sounds.shuffle()
 	speech_audio.stream = _flee_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.FLEE
 	speech_audio.play()
@@ -268,10 +268,10 @@ func play_flee_sound():
 
 # Needs logic for categories of question lines
 func play_dialog_q_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_dialog_q_sounds.shuffle()
 	speech_audio.stream = _dialog_q_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.DIALOG_Q
 	speech_audio.play()
@@ -279,10 +279,10 @@ func play_dialog_q_sound():
 
 # Needs logic for categories of response lines
 func play_dialog_a_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_dialog_a_sounds.shuffle()
 	speech_audio.stream = _dialog_a_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.DIALOG_A
 	speech_audio.play()
@@ -290,50 +290,50 @@ func play_dialog_a_sound():
 
 # Needs logic for each sequence
 func play_dialog_sequence_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_dialog_sequence_sounds.shuffle()
 	speech_audio.stream = _dialog_sequence_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.DIALOG_SEQUENCE
 	speech_audio.play()
 
 
 func play_surprised_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_surprised_sounds.shuffle()
 	speech_audio.stream = _surprised_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.SURPRISED
 	speech_audio.play()
 
 
 func play_fire_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_fire_sounds.shuffle()
 	speech_audio.stream = _fire_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.FIRE
 	speech_audio.play()
 
 
 func play_snake_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_snake_sounds.shuffle()
 	speech_audio.stream = _snake_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.SNAKE
 	speech_audio.play()
 
 
 func play_bomb_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	_bomb_sounds.shuffle()
 	speech_audio.stream = _bomb_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.BOMB
 	speech_audio.play()

--- a/scenes/character_audio.gd
+++ b/scenes/character_audio.gd
@@ -20,6 +20,26 @@ var _clamber_sounds : Dictionary = {
 # Speech
 export var character_voice_path : String = "res://resources/sounds/voices/cultists/neophyte/dylanb_vo/"   # "res:// path to folder structure of this voice pack?"
 
+enum SpeechType {
+	IDLE,
+	ALERT,
+	DETECTION,
+	AMBUSH,
+	CHASE,
+	FIGHT,
+	RELOAD,
+	FLEE,
+	DIALOG_Q,
+	DIALOG_A,
+	DIALOG_SEQUENCE,
+	SURPRISED,
+	FIRE,
+	SNAKE,
+	BOMB
+}
+
+var last_speech_type
+
 var _idle_sounds : Array = []
 var _alert_sounds : Array = []
 var _detection_sounds : Array = []
@@ -140,147 +160,201 @@ func choose_voice():
 
 
 func play_idle_sound():
+	# Don't replay the last line
+	if last_speech_line == speech_audio.stream:
+		return
+	# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
+	if speech_audio.playing == true:
+		return
+	# Tracked to avoid repeating the same line
 	_idle_sounds.shuffle()
 	speech_audio.stream = _idle_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.IDLE
 	speech_audio.play()
-	print("played idle sound")
+	print("Played idle sound")
 
 
 func play_alert_sound():
+	if last_speech_line == speech_audio.stream:   # This is not working to stop duplicate lines =/
+		return 
+	if last_speech_type == SpeechType.ALERT or last_speech_type == SpeechType.DETECTION or last_speech_type == SpeechType.FIGHT:
+		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
+		if speech_audio.playing == true:
+			return
 	_alert_sounds.shuffle()
 	speech_audio.stream = _alert_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.ALERT
 	speech_audio.play()
-
+	print("Played alert sound")
+	
 
 func play_detection_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
+	if last_speech_type == SpeechType.ALERT or last_speech_type == SpeechType.DETECTION or last_speech_type == SpeechType.FIGHT:
+		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
+		if speech_audio.playing == true:
+			return
 	_detection_sounds.shuffle()
 	speech_audio.stream = _detection_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.DETECTION
 	speech_audio.play()
+	print("Played detection sound")
 
 
 func play_ambush_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_ambush_sounds.shuffle()
 	speech_audio.stream = _ambush_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.AMBUSH
 	speech_audio.play()
 
 
 func play_chase_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_chase_sounds.shuffle()
 	speech_audio.stream = _chase_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.CHASE
 	speech_audio.play()
 
 
 func play_fight_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
+	if !last_speech_type == SpeechType.FIGHT:   # Anything but fight
+		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
+		if speech_audio.playing == true:
+			return
 	_fight_sounds.shuffle()
 	speech_audio.stream = _fight_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.FIGHT
 	speech_audio.play()
+	print("Played fight sound")
 
 
 func play_reload_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
+	# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
+	if speech_audio.playing == true:
+		return
 	_reload_sounds.shuffle()
 	speech_audio.stream = _reload_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.RELOAD
 	speech_audio.play()
 
 
 func play_flee_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_flee_sounds.shuffle()
 	speech_audio.stream = _flee_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.FLEE
 	speech_audio.play()
 
 
-# needs logic for categories of question lines
+# Needs logic for categories of question lines
 func play_dialog_q_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_dialog_q_sounds.shuffle()
 	speech_audio.stream = _dialog_q_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.DIALOG_Q
 	speech_audio.play()
 
 
-# needs logic for categories of response lines
+# Needs logic for categories of response lines
 func play_dialog_a_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_dialog_a_sounds.shuffle()
 	speech_audio.stream = _dialog_a_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.DIALOG_A
 	speech_audio.play()
 
 
-# needs logic for each sequence
+# Needs logic for each sequence
 func play_dialog_sequence_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_dialog_sequence_sounds.shuffle()
 	speech_audio.stream = _dialog_sequence_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.DIALOG_SEQUENCE
 	speech_audio.play()
 
 
 func play_surprised_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_surprised_sounds.shuffle()
 	speech_audio.stream = _surprised_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.SURPRISED
 	speech_audio.play()
 
 
 func play_fire_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_fire_sounds.shuffle()
 	speech_audio.stream = _fire_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.FIRE
 	speech_audio.play()
 
 
 func play_snake_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_snake_sounds.shuffle()
 	speech_audio.stream = _snake_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.SNAKE
 	speech_audio.play()
 
 
 func play_bomb_sound():
+	if last_speech_line == speech_audio.stream:
+		return 
 	_bomb_sounds.shuffle()
 	speech_audio.stream = _bomb_sounds.front()
-	if last_speech_line == speech_audio.stream:
-		return # instead of playing
-	last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
+	last_speech_type = SpeechType.BOMB
 	speech_audio.play()
 
 
 # Signalled from the idle loop Wait Random
-func _on_BT_Wait_Random_cultist_idled():
+func _on_BT_Wait_Random_character_idled():
 	play_idle_sound()
+
+
+func _on_BT_Sound_Listener_unseen_sound_heard():
+	play_alert_sound()
+
+
+func _on_BT_Player_Sensor_character_detected():
+	play_detection_sound()
+
+
+func _on_BT_Go_To_Target_plans_to_approach():
+	play_fight_sound()
+
+
+func _on_BT_Reload_Gun_character_reloaded():
+	play_reload_sound()
 
 
 # Movement

--- a/scenes/character_audio.gd
+++ b/scenes/character_audio.gd
@@ -58,11 +58,11 @@ var _bomb_sounds : Array = []
 
 var _current_sound_dir : String = ""
 
-onready var speech_audio = $Speech
-onready var manipulation_audio = $Manipulation
-onready var movement_audio = $Movement
+onready var speech_audio = $Speech as AudioStreamPlayer3D
+onready var manipulation_audio = $Manipulation as AudioStreamPlayer3D
+onready var movement_audio = $Movement as AudioStreamPlayer3D
 
-onready var last_speech_line = speech_audio.stream # tracked to avoid repeating the same line
+onready var last_speech_line   # Tracked to avoid repeating the same line
 
 
 func _ready():
@@ -160,15 +160,16 @@ func choose_voice():
 
 
 func play_idle_sound():
-	# Don't replay the last line
-	if last_speech_line == speech_audio.stream:
-		return
 	# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
-	if speech_audio.playing == true:
+	if speech_audio.is_playing() == true:
+		print("Sound already playing (idle called this)")
 		return
 	# Tracked to avoid repeating the same line
 	_idle_sounds.shuffle()
 	speech_audio.stream = _idle_sounds.front()
+	# Don't replay the last line
+	if last_speech_line == speech_audio.stream:
+		return
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.IDLE
 	speech_audio.play()
@@ -176,14 +177,15 @@ func play_idle_sound():
 
 
 func play_alert_sound():
-	if last_speech_line == speech_audio.stream:   # This is not working to stop duplicate lines =/
-		return 
 	if last_speech_type == SpeechType.ALERT or last_speech_type == SpeechType.DETECTION or last_speech_type == SpeechType.FIGHT:
 		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
-		if speech_audio.playing == true:
+		if speech_audio.is_playing() == true:
+			print("Sounds already playing (alert called this)")
 			return
 	_alert_sounds.shuffle()
 	speech_audio.stream = _alert_sounds.front()
+	if last_speech_line == speech_audio.stream:   # This is not working to stop duplicate lines =/
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.ALERT
 	speech_audio.play()
@@ -191,14 +193,15 @@ func play_alert_sound():
 	
 
 func play_detection_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	if last_speech_type == SpeechType.ALERT or last_speech_type == SpeechType.DETECTION or last_speech_type == SpeechType.FIGHT:
 		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
-		if speech_audio.playing == true:
+		if speech_audio.is_playing() == true:
+			print("Sounds already playing (detection called this)")
 			return
 	_detection_sounds.shuffle()
 	speech_audio.stream = _detection_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.DETECTION
 	speech_audio.play()
@@ -226,14 +229,14 @@ func play_chase_sound():
 
 
 func play_fight_sound():
-	if last_speech_line == speech_audio.stream:
-		return 
 	if !last_speech_type == SpeechType.FIGHT:   # Anything but fight
 		# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
-		if speech_audio.playing == true:
+		if speech_audio.is_playing() == true:
 			return
 	_fight_sounds.shuffle()
 	speech_audio.stream = _fight_sounds.front()
+	if last_speech_line == speech_audio.stream:
+		return 
 	last_speech_line = speech_audio.stream   # Tracked to avoid repeating the same line
 	last_speech_type = SpeechType.FIGHT
 	speech_audio.play()
@@ -244,7 +247,7 @@ func play_reload_sound():
 	if last_speech_line == speech_audio.stream:
 		return 
 	# This means he doesn't interrupt itself - for detection lines, they should, but not idles, reloads, etc
-	if speech_audio.playing == true:
+	if speech_audio.is_playing() == true:
 		return
 	_reload_sounds.shuffle()
 	speech_audio.stream = _reload_sounds.front()

--- a/scenes/characters/character.gd
+++ b/scenes/characters/character.gd
@@ -104,7 +104,9 @@ export(AttackTypes.Types) var damage_type : int = 0
 export (float) var kick_impulse
 
 var state = State.STATE_WALKING
+
 var light_level : float = 0.0
+
 var velocity : Vector3 = Vector3.ZERO
 var _current_velocity : Vector3 = Vector3.ZERO
 
@@ -720,6 +722,5 @@ func _on_Inventory_mainhand_slot_changed(previous, current):
 	if inventory.hotbar[current] != null :
 		pass
 	else:
-		print("_on_Inventory_mainhand_slot_changed() reached in character.gd")
 		current_mainhand_item_animation = hold_states.MELEE_ITEM
 		mainhand_animation = Animation_state.NOT_EQUIPPED

--- a/scenes/characters/character.gd
+++ b/scenes/characters/character.gd
@@ -675,22 +675,22 @@ func check_state_animation(delta):
 
 func check_current_item_animation():
 		# This code checks the current item type the player is equipping and set the animation that matches that item in the animation tree
-		var main_hand_object = inventory.current_mainhand_slot
-		var off_hand_object = inventory.current_offhand_slot
+		var mainhand_object = inventory.current_mainhand_slot
+		var offhand_object = inventory.current_offhand_slot
 		
-		# temporary hack (issue #409)
-		if not is_instance_valid(inventory.hotbar[main_hand_object]):
-			inventory.hotbar[main_hand_object] = null
+		# temporary hack (issue #409) - not sure it's necessary
+#		if not is_instance_valid(inventory.hotbar[mainhand_object]):
+#			inventory.hotbar[mainhand_object] = null
 		
-		if inventory.hotbar[main_hand_object] is GunItem or inventory.hotbar[off_hand_object] is GunItem :
-			if inventory.hotbar[main_hand_object].item_size == 0:
+		if inventory.hotbar[mainhand_object] is GunItem:
+			if inventory.hotbar[mainhand_object].item_size == 0:
 				current_mainhand_item_animation = hold_states.SMALL_GUN_ITEM
 			else:
 				current_mainhand_item_animation = hold_states.LARGE_GUN_ITEM
 #		elif inventory.hotbar[main_hand_object] is LanternItem or inventory.hotbar[off_hand_object] is LanternItem:
 #			print("Carried Lantern")
 			#update this to work for items animations
-		elif inventory.hotbar[main_hand_object] is MeleeItem or inventory.hotbar[off_hand_object] is MeleeItem:
+		elif inventory.hotbar[mainhand_object] is MeleeItem:
 			current_mainhand_item_animation = hold_states.MELEE_ITEM
 			print("Melee Item")
 

--- a/scenes/characters/cultists/cultist.gd
+++ b/scenes/characters/cultists/cultist.gd
@@ -5,6 +5,8 @@ extends Character
 var weapon_resource = preload("res://scenes/objects/pickable_items/equipment/ranged/double-barrel_shotgun/shotgun_item.tscn")
 var ammo_resource = preload("res://resources/tiny_items/ammunition/shotgun_shell.tres")
 
+onready var direct_player_sight_sensor : Node = $Body/DirectPlayerSight
+
 
 #enum #LOADOUT PACKAGES FOR NEOPHYTES:
 #(# in parentheses is probability weight) {

--- a/scenes/characters/cultists/neophyte.tscn
+++ b/scenes/characters/cultists/neophyte.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://scenes/characters/character.tscn" type="PackedScene" id=1]
 [ext_resource path="res://core/ai/check_nodes/bt_gun_cooldown.gd" type="Script" id=2]
@@ -22,6 +22,9 @@
 [ext_resource path="res://core/ai/check_nodes/bt_gun_has_ammo.gd" type="Script" id=20]
 [ext_resource path="res://core/ai/action_nodes/bt_reload_gun.gd" type="Script" id=21]
 
+[sub_resource type="CapsuleShape" id=6]
+radius = 0.4
+
 [sub_resource type="SphereShape" id=4]
 radius = 3.5
 
@@ -37,7 +40,8 @@ mass = 70.0
 _legcast = NodePath("Legs/Feet")
 
 [node name="CollisionShape" parent="." index="0"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.9, -0.04 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.947582, -0.158151 )
+shape = SubResource( 6 )
 
 [node name="MainHandEquipmentRoot" parent="." index="3"]
 unique_name_in_owner = false
@@ -140,7 +144,7 @@ transform = Transform( -1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 0
 bones/137/bound_children = [ NodePath("MainHandAttachment") ]
 
 [node name="MainHandAttachment" type="BoneAttachment" parent="Body/CultistNeophyteNoCape/rig_deform/Skeleton" index="1"]
-transform = Transform( -0.824783, 0.554134, 0.113921, -0.0117036, -0.218051, 0.97591, 0.56561, 0.803572, 0.18626, -0.128081, 15.1181, 2.97011 )
+transform = Transform( -0.826811, 0.551101, 0.113634, -0.0104032, -0.21689, 0.976181, 0.562608, 0.805929, 0.185006, -0.138101, 15.1215, 2.97395 )
 bone_name = "DEF-hand.R"
 
 [node name="MainHandEquipmentRoot" type="Position3D" parent="Body/CultistNeophyteNoCape/rig_deform/Skeleton/MainHandAttachment" index="0"]

--- a/scenes/characters/cultists/neophyte.tscn
+++ b/scenes/characters/cultists/neophyte.tscn
@@ -26,7 +26,7 @@
 radius = 3.5
 
 [sub_resource type="SphereShape" id=5]
-radius = 30.0
+radius = 100.0
 
 [node name="Cultist" instance=ExtResource( 1 )]
 script = ExtResource( 18 )
@@ -41,6 +41,7 @@ transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.9,
 
 [node name="MainHandEquipmentRoot" parent="." index="3"]
 unique_name_in_owner = false
+transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0.2, 1.2, -0.3 )
 
 [node name="BehaviorTree" type="Node" parent="." index="5"]
 script = ExtResource( 6 )
@@ -52,36 +53,22 @@ script = ExtResource( 8 )
 [node name="BT_Sequence2" type="Node" parent="BehaviorTree/BT_Selector" index="0"]
 script = ExtResource( 9 )
 
-[node name="BT_Player_Sensor" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2" index="0"]
+[node name="BT_Sound_Listener" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2" index="0"]
+script = ExtResource( 17 )
+direct_player_sight = NodePath("../../../../Body/DirectPlayerSight")
+listener = NodePath("../../../../Body/SoundListener")
+
+[node name="BT_Player_Sensor" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2" index="1"]
 script = ExtResource( 11 )
 sensor = NodePath("../../../../Body/DirectPlayerSight")
-
-[node name="BT_Sound_Listener" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2" index="1"]
-script = ExtResource( 17 )
-listener = NodePath("../../../../Body/SoundListener")
 
 [node name="BT_Sequence" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2" index="2"]
 script = ExtResource( 9 )
 
-[node name="BT_Selector" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="0"]
-script = ExtResource( 8 )
-
-[node name="BT_Approach_Random_Distance" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector" index="0"]
-script = ExtResource( 13 )
-listener = NodePath("../../../../../../Body/SoundListener")
-
-[node name="BT_Go_To_Target" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector" index="1"]
-script = ExtResource( 12 )
-
-[node name="BT_Look_At_Target" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="1"]
+[node name="BT_Look_At_Target" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="0"]
 script = ExtResource( 14 )
 
-[node name="BT_Wait_Random3" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="2"]
-script = ExtResource( 10 )
-max_time = 1.6
-min_time = 0.8
-
-[node name="BT_Selector2" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="3"]
+[node name="BT_Selector2" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="1"]
 script = ExtResource( 8 )
 
 [node name="BT_Gun_Has_Ammo" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector2" index="0"]
@@ -92,6 +79,22 @@ script = ExtResource( 19 )
 
 [node name="BT_Reload_Gun" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector2" index="2"]
 script = ExtResource( 21 )
+
+[node name="BT_Selector" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="2"]
+script = ExtResource( 8 )
+
+[node name="BT_Approach_Random_Distance" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector" index="0"]
+script = ExtResource( 13 )
+listener = NodePath("../../../../../../Body/SoundListener")
+
+[node name="BT_Go_To_Target" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector" index="1"]
+script = ExtResource( 12 )
+speed = 3.0
+
+[node name="BT_Wait_Random3" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="3"]
+script = ExtResource( 10 )
+max_time = 1.6
+min_time = 0.8
 
 [node name="BT_Gun_Cooldown" type="Node" parent="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence" index="4"]
 script = ExtResource( 2 )
@@ -124,26 +127,44 @@ script = ExtResource( 7 )
 [node name="Body" parent="." index="6"]
 script = ExtResource( 4 )
 
-[node name="DirectPlayerSight" parent="Body" index="2" instance=ExtResource( 5 )]
+[node name="DirectPlayerSight" parent="Body" index="0" instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.6969, 0 )
 character = NodePath("../..")
-FOV = 120.0
 
-[node name="CultistNeophyteNoCape" parent="Body" index="3" instance=ExtResource( 15 )]
+[node name="SoundListener" parent="Body" index="1" instance=ExtResource( 16 )]
+
+[node name="CultistNeophyteNoCape" parent="Body" index="2" instance=ExtResource( 15 )]
 transform = Transform( -1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 0 )
 
+[node name="Skeleton" parent="Body/CultistNeophyteNoCape/rig_deform" index="0"]
+bones/137/bound_children = [ NodePath("MainHandAttachment") ]
+
 [node name="MainHandAttachment" type="BoneAttachment" parent="Body/CultistNeophyteNoCape/rig_deform/Skeleton" index="1"]
-transform = Transform( -0.820184, 0.560794, 0.114602, -0.0144487, -0.220449, 0.975335, 0.572209, 0.798289, 0.188837, -0.103486, 15.1065, 2.96159 )
+transform = Transform( -0.824783, 0.554134, 0.113921, -0.0117036, -0.218051, 0.97591, 0.56561, 0.803572, 0.18626, -0.128081, 15.1181, 2.97011 )
 bone_name = "DEF-hand.R"
 
 [node name="MainHandEquipmentRoot" type="Position3D" parent="Body/CultistNeophyteNoCape/rig_deform/Skeleton/MainHandAttachment" index="0"]
 unique_name_in_owner = true
 transform = Transform( 9.84473, 1.17404, 2.02384, 1.02098, -4.38713, -8.65556, 0.2866, 9.34465, -4.16409, -0.605394, 0.872764, 0.219596 )
 
-[node name="SoundListener" parent="Body" index="4" instance=ExtResource( 16 )]
-sensor = NodePath("../DirectPlayerSight")
+[node name="NearSoundDetector" type="Area" parent="." index="7"]
+collision_layer = 2
+monitorable = false
 
-[node name="Hitbox" parent="." index="7" groups=["CHARACTER"]]
+[node name="CollisionShape" type="CollisionShape" parent="NearSoundDetector" index="0"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.938325, 0 )
+shape = SubResource( 4 )
+
+[node name="FarSoundDetector" type="Area" parent="." index="8"]
+collision_layer = 0
+collision_mask = 67
+monitorable = false
+
+[node name="CollisionShape" type="CollisionShape" parent="FarSoundDetector" index="0"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.938325, 0 )
+shape = SubResource( 5 )
+
+[node name="Hitbox" parent="." index="9" groups=["CHARACTER"]]
 visible = true
 collision_layer = 8
 
@@ -152,25 +173,8 @@ visible = false
 
 [node name="Speech" parent="Audio" index="0"]
 unit_db = 10.0
-unit_size = 4.0
 max_db = 6.0
-
-[node name="PlayerDetector" type="Area" parent="." index="16"]
-collision_layer = 2
-monitorable = false
-
-[node name="CollisionShape" type="CollisionShape" parent="PlayerDetector" index="0"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.938325, 0 )
-shape = SubResource( 4 )
-
-[node name="FarSoundDetector" type="Area" parent="." index="17"]
-collision_layer = 0
-collision_mask = 67
-monitorable = false
-
-[node name="CollisionShape" type="CollisionShape" parent="FarSoundDetector" index="0"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.938325, 0 )
-shape = SubResource( 5 )
+max_distance = 12.0
 
 [node name="AnimationPlayer" parent="." index="19"]
 root_node = NodePath("../Body/CultistNeophyteNoCape")
@@ -180,9 +184,13 @@ active = true
 parameters/ADS_State/current = 2
 parameters/Rifle_strafe_vector/blend_position = Vector2( 0, -0.0172414 )
 
-[connection signal="cultist_idled" from="BehaviorTree/BT_Selector/BT_Sequence/BT_Wait_Random" to="Audio" method="_on_BT_Wait_Random_cultist_idled"]
-[connection signal="body_entered" from="PlayerDetector" to="Body/DirectPlayerSight" method="_on_PlayerDetector_body_entered"]
-[connection signal="body_exited" from="PlayerDetector" to="Body/DirectPlayerSight" method="_on_PlayerDetector_body_exited"]
+[connection signal="unseen_sound_heard" from="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sound_Listener" to="Audio" method="_on_BT_Sound_Listener_unseen_sound_heard"]
+[connection signal="character_detected" from="BehaviorTree/BT_Selector/BT_Sequence2/BT_Player_Sensor" to="Audio" method="_on_BT_Player_Sensor_character_detected"]
+[connection signal="character_reloaded" from="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector2/BT_Reload_Gun" to="Audio" method="_on_BT_Reload_Gun_character_reloaded"]
+[connection signal="plans_to_approach" from="BehaviorTree/BT_Selector/BT_Sequence2/BT_Sequence/BT_Selector/BT_Go_To_Target" to="Audio" method="_on_BT_Go_To_Target_plans_to_approach"]
+[connection signal="character_idled" from="BehaviorTree/BT_Selector/BT_Sequence/BT_Wait_Random" to="Audio" method="_on_BT_Wait_Random_character_idled"]
+[connection signal="body_entered" from="NearSoundDetector" to="Body/SoundListener" method="_on_NearSoundDetector_body_entered"]
+[connection signal="body_exited" from="NearSoundDetector" to="Body/SoundListener" method="_on_NearSoundDetector_body_exited"]
 [connection signal="body_entered" from="FarSoundDetector" to="Body/SoundListener" method="_on_FarSoundDetector_body_entered"]
 [connection signal="body_exited" from="FarSoundDetector" to="Body/SoundListener" method="_on_FarSoundDetector_body_exited"]
 

--- a/scenes/characters/inventory.gd
+++ b/scenes/characters/inventory.gd
@@ -197,9 +197,9 @@ func equip_mainhand_item():
 		
 	var item : EquipmentItem = hotbar[current_mainhand_slot] as EquipmentItem
 	if item:
-		# Can't Equip a Bulky Item simultaneously with a normal item
+		# Can't equip a Bulky Item simultaneously with a normal item
 		drop_bulky_item()
-		# Can't Equip item on both hands
+		# Can't equip item in both hands
 		if current_offhand_equipment == item:
 			unequip_offhand_item()
 		item.item_state = GlobalConsts.ItemState.EQUIPPED

--- a/scenes/characters/inventory.gd
+++ b/scenes/characters/inventory.gd
@@ -106,27 +106,31 @@ func add_item(item : PickableItem) -> bool:
 			
 			### Probably can be cleaned up - part 1 is to put lights offhand, part 2 is everything else
 			# Checks if something is in offhand; if not, and this is a light, put it there
-			if current_offhand_equipment == null:
+			if current_offhand_equipment == null or current_offhand_equipment == EmptyHand:
+				print("Offhand null or empty hands")
 				if item is CandleItem or item is TorchItem or item is CandelabraItem or item is LanternItem:
+					print("...and is a light")
 					if hotbar[slot] != null and !current_mainhand_slot:
+						print ("...slot isn't empty and it's not the mainhand one")
 						slot = current_offhand_slot
 					if hotbar[slot] != null:
 						slot = hotbar.find(null)
-						if slot == current_mainhand_slot:
-							slot += 1
-							if slot != 10:
-								hotbar[slot] = item
-								# Schedule the item removal from the world
-								if item.is_inside_tree():
-									item.get_parent().remove_child(item)
-								
-								emit_signal("hotbar_changed", slot)
-								emit_signal("inventory_changed")
-								
-								if not bulky_equipment:
-									set_offhand_slot(slot)   # This is what puts it in off-hand
-									equip_offhand_item()
-									return true
+					if slot == current_mainhand_slot:
+						slot += 1
+					if slot != 10:
+						hotbar[slot] = item
+						print("Light-source going to slot ", slot)
+						# Schedule the item removal from the world
+						if item.is_inside_tree():
+							item.get_parent().remove_child(item)
+						
+						emit_signal("hotbar_changed", slot)
+						emit_signal("inventory_changed")
+						
+						if not bulky_equipment:
+							set_offhand_slot(slot)   # This is what puts it in off-hand
+							equip_offhand_item()
+							return true
 					
 			### Otherwise, normal rules: Select an empty slot, prioritizing the current one, if empty
 			slot = current_mainhand_slot

--- a/scenes/characters/inventory.gd
+++ b/scenes/characters/inventory.gd
@@ -102,17 +102,41 @@ func add_item(item : PickableItem) -> bool:
 			unequip_offhand_item()
 			equip_bulky_item(item)
 		else:
-			# Select an empty slot, prioritizing the current one, if empty
-			var slot : int = current_mainhand_slot
-			# Then the offhand
+			var slot = 10   # Defaulting to empty hands
 			
+			### Probably can be cleaned up - part 1 is to put lights offhand, part 2 is everything else
+			# Checks if something is in offhand; if not, and this is a light, put it there
+			if current_offhand_equipment == null:
+				if item is CandleItem or item is TorchItem or item is CandelabraItem or item is LanternItem:
+					if hotbar[slot] != null and !current_mainhand_slot:
+						slot = current_offhand_slot
+					if hotbar[slot] != null:
+						slot = hotbar.find(null)
+						if slot == current_mainhand_slot:
+							slot += 1
+							if slot != 10:
+								hotbar[slot] = item
+								# Schedule the item removal from the world
+								if item.is_inside_tree():
+									item.get_parent().remove_child(item)
+								
+								emit_signal("hotbar_changed", slot)
+								emit_signal("inventory_changed")
+								
+								if not bulky_equipment:
+									set_offhand_slot(slot)   # This is what puts it in off-hand
+									equip_offhand_item()
+									return true
+					
+			### Otherwise, normal rules: Select an empty slot, prioritizing the current one, if empty
+			slot = current_mainhand_slot
+			# Then the offhand, preferring this slot for lights
 			if hotbar[slot] != null:
 				slot = current_offhand_slot
-				
 			# Then the first empty slot
 			if hotbar[slot] != null:
 				slot = hotbar.find(null)
-			# This checks if the slot to add the item isnt the item free slot then Adds the item to the slot
+			# This checks if the slot to add the item isn't the item free slot then adds the item to the slot
 			if slot != 10:
 				hotbar[slot] = item
 				# Schedule the item removal from the world
@@ -121,13 +145,15 @@ func add_item(item : PickableItem) -> bool:
 				
 				emit_signal("hotbar_changed", slot)
 				emit_signal("inventory_changed")
+				
 				# Autoequip if possible
+				# Everything else including another light-source, just put it in the main-hand
 				if current_mainhand_slot == slot and not bulky_equipment:
 					equip_mainhand_item()
-
+				
 				elif current_offhand_slot == slot and not bulky_equipment:
 					equip_offhand_item()
-				
+					
 	return true
 
 
@@ -309,11 +335,11 @@ func drop_hotbar_slot(slot : int) -> Node:
 # note that the drop is done in a deferred manner
 func _drop_item(item : EquipmentItem):
 	item.item_state = GlobalConsts.ItemState.DROPPED
-	if !GameManager.game:   # this is here for test scenes
+	if !GameManager.game:   # This is here for test scenes
 		item.global_transform = drop_position_node.global_transform
 		find_parent("TestWorld").add_child(item)
 		return
-	if GameManager.game.level:   # this is for the real game
+	if GameManager.game.level:   # This is for the real game
 		item.global_transform = drop_position_node.global_transform
 		if item.can_attach == true:
 #			item.get_parent().remove_child(item)

--- a/scenes/characters/light_detect.gd
+++ b/scenes/characters/light_detect.gd
@@ -1,5 +1,6 @@
 extends Spatial
 
+
 var level1 : float
 var level : float
 
@@ -43,6 +44,25 @@ func _process(delta):
 	if (level1 > level):
 		level = level1
 	
+	# If holding a lit light-source, no crouching and hiding for you
+	# So messy how this nest is required for this
+	if owner.inventory.get_mainhand_item():
+		if owner.inventory.get_mainhand_item() is EmptyHand:
+			return
+		if owner.inventory.get_mainhand_item() is CandleItem or owner.inventory.get_mainhand_item() is TorchItem or owner.inventory.get_mainhand_item() is CandelabraItem or owner.inventory.get_mainhand_item() is LanternItem:
+			if owner.inventory.get_mainhand_item().is_lit == true:
+				owner.light_level = level
+				return
+	if owner.inventory.get_offhand_item():
+		if owner.inventory.get_offhand_item() is EmptyHand:
+			return
+		if owner.inventory.get_offhand_item() is CandleItem or owner.inventory.get_offhand_item() is TorchItem or owner.inventory.get_offhand_item() is CandelabraItem or owner.inventory.get_offhand_item() is LanternItem:
+#			print("Offhand is Candle, Torch, Candelabra, or Lantern")
+			if owner.inventory.get_offhand_item().is_lit == true:
+				owner.light_level = level
+				return
+
+	# Okay, you're crouching without a lit light-source in hand; that's cool
 	if owner.state == owner.State.STATE_CROUCHING:
 		level *= (1 - pow(1 - level, 5))
 	owner.light_level = level

--- a/scenes/characters/light_detection.tscn
+++ b/scenes/characters/light_detection.tscn
@@ -8,7 +8,7 @@ height = 0.5
 radial_segments = 13
 rings = 3
 
-[node name="Light_detection" type="Spatial"]
+[node name="LightDetection" type="Spatial"]
 script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]

--- a/scenes/characters/player/player_anims.gd
+++ b/scenes/characters/player/player_anims.gd
@@ -30,7 +30,7 @@ func _physics_process(delta):
 
 func check_current_item_animation():
 	
-	#This code checks the current item equipped by the player and updates the current_mainhand_item_animation to correspond to it 
+	# This code checks the current item equipped by the player and updates the current_mainhand_item_animation to correspond to it 
 		var main_hand_object = inventory.current_mainhand_slot
 		var off_hand_object = inventory.current_offhand_slot
 

--- a/scenes/characters/player/player_controller.gd
+++ b/scenes/characters/player/player_controller.gd
@@ -54,7 +54,6 @@ export var interact_distance : float = 0.75
 export var lock_mouse : bool = true
 export var head_bob_enabled : bool = true
 
-var light_level : float = 0.0
 var velocity : Vector3 = Vector3.ZERO
 var _bob_time : float = 0.0
 var _clamber_m = null
@@ -469,9 +468,9 @@ func update_throw_state(delta : float):
 func empty_slot():
 	var inv = character.inventory
 	if inv.hotbar != null:
-		var gun = preload("res://scenes/objects/pickable_items/equipment/empty_slot/_empty_hand.tscn").instance()
+		var item = preload("res://scenes/objects/pickable_items/equipment/empty_slot/_empty_hand.tscn").instance()
 		if  !inv.hotbar.has(10):
-			inv.hotbar[10] = gun
+			inv.hotbar[10] = item
 
 
 func throw_consumable():
@@ -484,7 +483,7 @@ func throw_consumable():
 			item = inv.get_offhand_item()
 			inv.drop_offhand_item()
 		if item:
-			var impulse = active_mode.get_aim_direction()*throw_strength
+			var impulse = active_mode.get_aim_direction() * throw_strength
 			# At this point, the item is still equipped, so we wait until
 			# it exits the tree and is re inserted in the world
 			item.apply_central_impulse(impulse)
@@ -504,7 +503,7 @@ func handle_inventory(delta : float):
 				throw_state = ThrowState.IDLE
 				owner.change_equipment_in(true)
 
-	# Offhand slot selection
+	# Off-hand slot selection
 	if Input.is_action_just_pressed("cycle_offhand_slot") and owner.is_reloading == false:
 		var start_slot = inv.current_offhand_slot
 		var new_slot = (start_slot + 1)%inv.hotbar.size()

--- a/scenes/characters/player/player_controller.gd
+++ b/scenes/characters/player/player_controller.gd
@@ -549,10 +549,10 @@ func handle_inventory(delta : float):
 				inv.get_mainhand_item().use_reload()
 				throw_state = ThrowState.IDLE
 
-		if Input.is_action_just_pressed("offhand_use"):
-			if inv.get_offhand_item():
-				inv.get_offhand_item().use_primary()
-				throw_state = ThrowState.IDLE
+	if Input.is_action_just_pressed("offhand_use"):
+		if inv.get_offhand_item():
+			inv.get_offhand_item().use_primary()
+			throw_state = ThrowState.IDLE
 
 	# Change the visual filter to change art style of game, such as dither, pixelation, VHS, etc
 	if Input.is_action_just_pressed("change_screen_filter"):

--- a/scenes/characters/player/player_hit.gd
+++ b/scenes/characters/player/player_hit.gd
@@ -20,6 +20,7 @@ func _process(delta):
 	var player := owner as Player
 	debug_label.text = (
 		"player light_level = " + str(player.light_level) + "\n"
+		+ "player noise_level = " + str(player.noise_level) + "\n"
 		+ "player on floor = " +  str(player.is_on_floor()) + "\n"
 		+ "player position = " +  str(player.translation) + "\n"
 	)

--- a/scenes/core/game.gd
+++ b/scenes/core/game.gd
@@ -24,6 +24,7 @@ func _init():
 func _ready():
 	yield(get_tree().create_timer(1), "timeout")
 	load_level(start_level_scn)
+	BackgroundMusic.stop()   # Just in case
 
 
 func load_level(packed : PackedScene):

--- a/scenes/objects/large_objects/sarcophagi/dragging_sound.gd
+++ b/scenes/objects/large_objects/sarcophagi/dragging_sound.gd
@@ -3,7 +3,7 @@ extends RigidBody
 
 var sound_vol : float = 10
 var noise_level : float = 0
-var item_max_noise_level : float = 80
+var item_max_noise_level : int = 40
 var item_sound_level : float = 60
 export var item_drag_sound : AudioStream
 export var item_drop_sound : AudioStream

--- a/scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.gd
+++ b/scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.gd
@@ -1,8 +1,9 @@
+class_name CandleItem
 extends ConsumableItem
 
 
-#var has_ever_been_on = false
 signal item_is_dropped
+
 var is_lit = true
 var burn_time : float
 var is_depleted : bool = false
@@ -21,14 +22,25 @@ onready var firelight = $FireOrigin/Fire/Light
 
 func _ready():
 	light_timer = $BurnTime
-	light_timer.connect("timeout", self, "light_depleted")
+	self.connect("item_is_dropped", self, "item_drop")
+	light_timer.connect("timeout", self, "_light_depleted")
 	burn_time = 3600.0
-	light_timer.set_wait_time(burn_time)
-	light_timer.start()
-	
-	material = $MeshInstance.get_surface_material(0)
-	new_material = material.duplicate()
-	$MeshInstance.set_surface_material(0,new_material)
+	light()
+
+
+func _process(delta):
+	if item_state == GlobalConsts.ItemState.DROPPED:
+		$Ignite/CollisionShape.disabled = false
+		is_dropped = true
+		
+		if is_dropped and not is_just_dropped:
+			is_just_dropped = true
+			self.emit_signal("item_is_dropped")
+			item_drop()
+	else:
+		$Ignite/CollisionShape.disabled = true
+		is_dropped = false
+		is_just_dropped = false
 
 
 func light():
@@ -39,7 +51,7 @@ func light():
 		$FireOrigin/Fire.visible = not $FireOrigin/Fire.visible
 		firelight.visible = not firelight.visible
 		$MeshInstance.cast_shadow = false
-		$MeshInstance.get_surface_material(0).emission_enabled  = not $MeshInstance.get_surface_material(0).emission_enabled
+		$MeshInstance.get_surface_material(0).emission_enabled = true
 		
 		is_lit = true
 		light_timer.set_wait_time(burn_time)
@@ -49,8 +61,6 @@ func light():
 func unlight():
 	if not is_depleted:
 		$AnimationPlayer.stop()
-		if !is_dropped:
-			$Sounds/BlowOutSound.play()
 		$MeshInstance.get_surface_material(0).emission_enabled = false
 	#	$FireOrigin/Fire.emitting = false
 		$FireOrigin/Fire.visible = false
@@ -62,22 +72,28 @@ func unlight():
 
 
 func _use_primary():
+	print("Lit state before use_primary: ", is_lit)
 	if is_lit == false:
 		light()
 	else:
 		unlight()
+		$Sounds/BlowOutSound.play()
 
 
 func _item_state_changed(previous_state, current_state):
-	if current_state == GlobalConsts.ItemState.INVENTORY:
-		switch_away()
+#	if previous_state == GlobalConsts.ItemState.EQUIPPED and current_state == GlobalConsts.ItemState.DROPPED:
+#		unlight()
+#		return
+#	if previous_state == GlobalConsts.ItemState.EQUIPPED:  
+#		unlight()
+#		$Sounds/BlowOutSound.play()   # This is the messed one, all jacked with the sound etc
+#	if previous_state == GlobalConsts.ItemState.EQUIPPED and current_state == GlobalConsts.ItemState.INVENTORY:
+#		$Sounds/BlowOutSound.play()
+#		unlight()
+	pass
 
 
-func switch_away():
-	unlight()
-
-
-func light_depleted():
+func _light_depleted():
 	burn_time = 0
 	unlight()
 	is_depleted = true

--- a/scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.tscn
+++ b/scenes/objects/pickable_items/equipment/consumable/disposable_lights/candle/candle.tscn
@@ -191,10 +191,6 @@ extents = Vector3( 0.02, 0.02, 0.02 )
 
 [node name="Candle" instance=ExtResource( 1 )]
 script = ExtResource( 3 )
-dropped_layers = 64
-dropped_mask = 1
-equipped_mode = 3
-item_size = 0
 item_name = "Candle"
 life_percentage_lose = 0.2
 prob_going_out = 0.9
@@ -215,6 +211,7 @@ script = ExtResource( 2 )
 
 [node name="Fire" type="MeshInstance" parent="FireOrigin" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00112008, 0.0137497, 0 )
+visible = false
 cast_shadow = 0
 mesh = SubResource( 49 )
 skeleton = NodePath("../../..")
@@ -223,6 +220,7 @@ script = ExtResource( 6 )
 
 [node name="Light" type="OmniLight" parent="FireOrigin/Fire" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.000501111, 0 )
+visible = false
 light_color = Color( 0.760784, 0.364706, 0.0470588, 1 )
 light_energy = 0.25
 shadow_enabled = true
@@ -255,3 +253,4 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0742746, 0 )
 shape = SubResource( 53 )
 
 [connection signal="item_state_changed" from="." to="." method="_item_state_changed"]
+[connection signal="timeout" from="BurnTime" to="." method="_light_depleted"]

--- a/scenes/objects/pickable_items/equipment/consumable/disposable_lights/torch/torch.gd
+++ b/scenes/objects/pickable_items/equipment/consumable/disposable_lights/torch/torch.gd
@@ -1,3 +1,4 @@
+class_name TorchItem
 extends ConsumableItem
 
 

--- a/scenes/objects/pickable_items/equipment/empty_slot/empty_hand.gd
+++ b/scenes/objects/pickable_items/equipment/empty_slot/empty_hand.gd
@@ -1,2 +1,2 @@
-class_name empty_hand
+class_name EmptyHand
 extends EquipmentItem

--- a/scenes/objects/pickable_items/equipment/equipment_item.gd
+++ b/scenes/objects/pickable_items/equipment/equipment_item.gd
@@ -38,19 +38,19 @@ func _use_reload():
 func use_primary():
 	_use_primary()
 	emit_signal("used_primary")
-	pass
+
 
 
 func use_secondary():
 	_use_secondary()
 	emit_signal("used_secondary")
-	pass
+
 
 
 func use_reload():
 	_use_reload()
 	emit_signal("used_reload")
-	pass
+
 
 
 func get_hold_transform() -> Transform:

--- a/scenes/objects/pickable_items/equipment/ranged/double-barrel_shotgun/shotgun_item.tscn
+++ b/scenes/objects/pickable_items/equipment/ranged/double-barrel_shotgun/shotgun_item.tscn
@@ -150,7 +150,7 @@ transform = Transform( -4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, -0.0
 shape = SubResource( 378 )
 
 [node name="RayCast" parent="." index="5"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.000195906, 0.0165546, -0.119145 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.000195906, 0.0165546, -0.0153745 )
 
 [node name="HoldPosition" parent="." index="6"]
 transform = Transform( 0.967347, 0.204731, 0.149416, -0.200553, 0.978753, -0.0426778, -0.154979, 0.0113183, 0.987853, 0.011, -0.0501159, 0.147841 )

--- a/scenes/objects/pickable_items/equipment/tool/light-sources/candelabra/candelabra.gd
+++ b/scenes/objects/pickable_items/equipment/tool/light-sources/candelabra/candelabra.gd
@@ -101,8 +101,6 @@ func light():
 func unlight():
 	if not is_depleted:
 		$AnimationPlayer.stop()
-		if !is_dropped:
-			$BlowOutSound.play()
 		$Candle1/MeshInstance.get_surface_material(0).emission_enabled = false
 		$Candle1/FireOrigin/Fire.visible = false
 		$Candle1/MeshInstance.cast_shadow = true
@@ -129,6 +127,7 @@ func _use_primary():
 		light()
 	else:
 		unlight()
+		$BlowOutSound.play()
 
 
 func _item_state_changed(previous_state, current_state):

--- a/scenes/objects/pickable_items/equipment/tool/light-sources/lanterns.gd
+++ b/scenes/objects/pickable_items/equipment/tool/light-sources/lanterns.gd
@@ -31,8 +31,8 @@ func _ready():
 	light_timer.set_wait_time(burn_time)
 	light_timer.start()
 	
-	if self.name == "BullseyeLantern":
-		print("burn time is = " + str(burn_time))
+#	if self.name == "BullseyeLantern":
+#		print("burn time is = " + str(burn_time))
 
 
 func _process(delta):

--- a/scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn
+++ b/scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn
@@ -193,7 +193,7 @@ unit_db = 30.0
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0359308, 0 )
 stream = ExtResource( 6 )
 
-[node name="Ignite" parent="." index="10"]
+[node name="Ignite" parent="." index="9"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0567762, 0.00329563 )
 
 [node name="CollisionShape" parent="Ignite" index="0"]

--- a/scenes/objects/pickable_items/pickable_item.gd
+++ b/scenes/objects/pickable_items/pickable_item.gd
@@ -19,7 +19,7 @@ var owner_character : Node = null
 var item_state = GlobalConsts.ItemState.DROPPED setget set_item_state
 onready var audio_player = get_node("DropSound")
 export var item_drop_sound : AudioStream
-var noise_level = 0   # noise detectable by characters
+var noise_level = 0   # Noise detectable by characters
 var item_max_noise_level = 5
 var item_sound_level = 10
 
@@ -54,9 +54,9 @@ func set_item_state(value : int) :
 func play_drop_sound(body):
 	if self.item_drop_sound and self.audio_player:
 		self.audio_player.stream = self.item_drop_sound
-		self.audio_player.unit_db = item_sound_level
+		self.audio_player.unit_db = item_sound_level   # This should eventually be based on speed
 		self.audio_player.play()
-		self.noise_level = item_max_noise_level
+		self.noise_level = item_max_noise_level   # This should eventually be based on speed
 
 
 func set_physics_dropped():

--- a/scenes/sensors/direct_player_sight/direct_player_sight.gd
+++ b/scenes/sensors/direct_player_sight/direct_player_sight.gd
@@ -6,12 +6,11 @@ extends PlayerSensor
 # You will lag so hard
 # Don't remove this comment :)
 
-
 const DetectionArea = preload("res://scenes/sensors/direct_player_sight/direct_sight_area.gd")
 
 export var character : NodePath
-export var FOV : float = 70 setget set_fov
-export var distance : float = 16 setget set_distance
+export var FOV : float = 120 setget set_fov
+export var distance : float = 32 setget set_distance
 
 onready var area : DetectionArea = $DirectSightArea
 onready var raycast : RayCast = $RayCast
@@ -21,8 +20,8 @@ var sensor_up_to_date : bool = false
 var player_visible : bool = false
 var player_position : Vector3 = Vector3.ZERO
 var player_near : bool = false
+var player_far : bool = false
 var player_seen : bool = false
-var player_close : bool = false
 
 
 func is_player_detected() -> bool:
@@ -42,7 +41,7 @@ func get_measured_position() -> Vector3:
 func update_sensor():
 	player_visible = false
 	for body in area.get_overlapping_bodies():
-		if body is Player and (body.light_level > 0.04 or (player_near and player_seen)):
+		if body is Player and (body.light_level > 0.03 or (player_near and player_seen)):
 			if not player_seen and player_near:
 				player_seen = true
 			var target = body.global_transform.origin
@@ -51,7 +50,7 @@ func update_sensor():
 			raycast.force_raycast_update()
 			
 			if (raycast.is_colliding() and raycast.get_collider().owner is Player and 
-					(raycast.get_collider().owner.light_level > 0.04 or (player_near and player_seen))):
+					(raycast.get_collider().owner.light_level > 0.03 or (player_near and player_seen))):
 				player_visible = true
 				player_position = body.global_transform.origin
 				return
@@ -93,16 +92,29 @@ func _ready():
 	get_tree().connect("idle_frame", self, "clear_sensor")
 
 
-func _on_PlayerDetector_body_entered(body):
+#func _on_PlayerDetector_body_entered(body):   # This needs to be repointed
+#	if body is Player:
+#		player_near = true
+#		if body.light_level > 0.03:
+#			print("Player_seen")
+#			player_seen = true
+#
+#
+#func _on_PlayerDetector_body_exited(body):
+#	if body is Player:
+#		player_near = false
+#		player_seen = false
+
+
+func _on_DirectSightArea_body_entered(body):
 	if body is Player:
-		player_close = true
 		player_near = true
-		if body.light_level > 0.04:
+		if body.light_level > 0.03:
+			print("Player seen")   # Why does this show immediately at start? Seeing before walls are there?
 			player_seen = true
 
 
-func _on_PlayerDetector_body_exited(body):
+func _on_DirectSightArea_body_exited(body):
 	if body is Player:
-		player_close = false
 		player_near = false
 		player_seen = false

--- a/scenes/sensors/direct_player_sight/direct_player_sight.tscn
+++ b/scenes/sensors/direct_player_sight/direct_player_sight.tscn
@@ -10,14 +10,18 @@ params_blend_mode = 1
 params_depth_draw_mode = 2
 albedo_color = Color( 0.6, 0.2, 0.1, 1 )
 
-[sub_resource type="CylinderMesh" id=4]
+[sub_resource type="CylinderMesh" id=2]
+top_radius = 0.0
+bottom_radius = 31.6878
+height = 32.0
+radial_segments = 4
+rings = 0
 
 [sub_resource type="ConvexPolygonShape" id=3]
-points = PoolVector3Array( 0, 16, 0, 0, 16, 0, 0, 16, 0, 0, 16, 0, 0, 16, 0, 0, -16, 31.6878, 31.6878, -16, 1.94032e-15, 3.88063e-15, -16, -31.6878, -31.6878, -16, -5.82095e-15, -7.76127e-15, -16, 31.6878, 0, -16, 0, 0, -16, 31.6878, 31.6878, -16, 1.94032e-15, 3.88063e-15, -16, -31.6878, -31.6878, -16, -5.82095e-15, -7.76127e-15, -16, 31.6878 )
+points = PoolVector3Array( 0, -16, -31.6878, -31.6878, -16, 0, 0, 16, 0, 31.6878, -16, 0, 0, -16, 31.6878 )
 
 [node name="DirectPlayerSight" type="Spatial"]
 script = ExtResource( 2 )
-distance = 32.0
 
 [node name="RayCast" type="RayCast" parent="."]
 cast_to = Vector3( 0, 0, -32 )
@@ -34,8 +38,11 @@ script = ExtResource( 1 )
 transform = Transform( 0.707107, 0, 0.707107, 0.707107, -4.37114e-08, -0.707107, 3.09086e-08, 1, -3.09086e-08, 0, 0, -16 )
 visible = false
 material_override = SubResource( 1 )
-mesh = SubResource( 4 )
+mesh = SubResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DirectSightArea"]
 transform = Transform( 0.707107, 0, 0.707107, 0.707107, -4.37114e-08, -0.707107, 3.09086e-08, 1, -3.09086e-08, 0, 0, -16 )
 shape = SubResource( 3 )
+
+[connection signal="body_entered" from="DirectSightArea" to="." method="_on_DirectSightArea_body_entered"]
+[connection signal="body_exited" from="DirectSightArea" to="." method="_on_DirectSightArea_body_exited"]


### PR DESCRIPTION
 alert, detect, fight voices
* fixed near sound which had been broken for awhile
* far sound less sens
* cleaned up sound and visual senses encapsulation
* BT go to target move speed based on whether idle or chasing
* walls reduce noise based on number of walls
* Holding a light ensures crouching doesn't lower your visibility (so you can't crouch with a candle in front of a cultist with impunity)
* fixed swap away unlighting of candle, torch, candelara, lantern
* made lights prefer to go to offhand
* fix regression due to unintended indenting of offhand in playercntrlr
* fix regression due to unneeded, assuming lines in character regarding animations