### PR TITLE
Refactor initial loot and cultists spawn

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -149,6 +149,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scenes/characters/character_audio.gd"
 }, {
+"base": "SpawnData",
+"class": "CharacterSpawnData",
+"language": "GDScript",
+"path": "res://scenes/worlds/procedural_world/character_spawn_data.gd"
+}, {
 "base": "Node",
 "class": "CharacterSpawner",
 "language": "GDScript",
@@ -453,6 +458,7 @@ _global_script_class_icons={
 "CandleItem": "",
 "Character": "",
 "CharacterAudio": "",
+"CharacterSpawnData": "",
 "CharacterSpawner": "",
 "CharacterState": "",
 "ClamberManager": "",

--- a/resources/world/world_data.gd
+++ b/resources/world/world_data.gd
@@ -617,6 +617,19 @@ func set_wall_meta(cell_index : int, direction : int, value = null):
 			wall_meta[idx] = value
 
 
+func has_door(cell_index: int, direction: int) -> bool:
+	var wall_type = get_wall_type(cell_index, direction)
+	var value := false
+	if (
+			wall_type == EdgeType.DOOR
+			or wall_type == EdgeType.HALFDOOR_N
+			or wall_type == EdgeType.HALFDOOR_P
+	):
+		value = true
+	
+	return value
+
+
 func get_wall_tile_index(cell_index : int, direction : int) -> int:
 	return wall_tile_index[4 * cell_index + direction]
 

--- a/resources/world/world_data.gd
+++ b/resources/world/world_data.gd
@@ -152,6 +152,7 @@ func clear():
 	
 	player_spawn_position = INVALID_STARTING_CELL
 	_objects_to_spawn.clear()
+	_characters_to_spawn.clear()
 	_cell_indexes_by_cell_type.clear()
 
 
@@ -234,6 +235,7 @@ var player_spawn_position := INVALID_STARTING_CELL
 #	cell_index_3: SpawnData,
 #}
 var _objects_to_spawn := {}
+var _characters_to_spawn := {}
 
 # Stores a arrays of cell indexes already filtered by cell type.
 # Private variable, use `get_cells_for(p_type: int)` to access the arrays.
@@ -487,11 +489,13 @@ func is_cell_free(cell_index: int) -> bool:
 	else:
 		if _objects_to_spawn.has(cell_index):
 			value = false
+		elif _characters_to_spawn.has(cell_index):
+			value = false
 	
 	return value
 
 
-func set_spawn_data_to_cell(cell_index: int, spawn_data: SpawnData) -> void:
+func set_object_spawn_data_to_cell(cell_index: int, spawn_data: SpawnData) -> void:
 	if _objects_to_spawn.has(cell_index):
 		push_error("Aborting. Cell %s is already occupied with: %s"%[cell_index, spawn_data])
 		return
@@ -501,6 +505,18 @@ func set_spawn_data_to_cell(cell_index: int, spawn_data: SpawnData) -> void:
 
 func get_objects_to_spawn() -> Dictionary:
 	return _objects_to_spawn
+
+
+func set_character_spawn_data_to_cell(cell_index: int, spawn_data: SpawnData) -> void:
+	if _characters_to_spawn.has(cell_index):
+		push_error("Aborting. Cell %s is already occupied with: %s"%[cell_index, spawn_data])
+		return
+	
+	_characters_to_spawn[cell_index] = spawn_data
+
+
+func get_characters_to_spawn() -> Dictionary:
+	return _characters_to_spawn
 
 
 func get_cell_surfacetype(cell_index : int) -> int:

--- a/scenes/worlds/procedural_world/character_spawn_data.gd
+++ b/scenes/worlds/procedural_world/character_spawn_data.gd
@@ -1,0 +1,70 @@
+# Write your doc string for this file here
+tool
+class_name CharacterSpawnData
+extends SpawnData
+
+### Member Variables and Dependencies -------------------------------------------------------------
+#--- signals --------------------------------------------------------------------------------------
+
+#--- enums ----------------------------------------------------------------------------------------
+
+#--- constants ------------------------------------------------------------------------------------
+
+const CHARACTER_CENTER_POSITION_OFFSER = Vector3(0.75, 0.0, 0.75)
+
+#--- public variables - order: export > normal var > onready --------------------------------------
+
+#--- private variables - order: export > normal var > onready -------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Built-in Virtual Overrides --------------------------------------------------------------------
+
+func _to_string() -> String:
+	var msg := "[CharacterSpawnData:%s | amount: %s scene_path: %s tranforms: %s]"%[
+			get_instance_id(), amount, scene_path, _transforms
+	]
+	return msg
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Public Methods --------------------------------------------------------------------------------
+
+func spawn_character_in(node: Node, should_log := false) -> Spatial:
+	var character = load(scene_path).instance() as Spatial
+	if character == null:
+		push_error("scene_path is not a Spatial: %s"%[scene_path])
+		return character
+	
+	character.transform = _transforms.front()
+	node.add_child(character, true)
+	
+	if should_log:
+		print("Character spawned: %s at: %s"%[character, character.translation])
+	
+	return character
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+func _set_amount(value: int) -> void:
+	if value != 1:
+		value = 1
+		push_warning("Can't spawn more than 1 character per cell")
+	
+	._set_amount(value)
+
+
+func _get_center_offset() -> Vector3:
+	return CHARACTER_CENTER_POSITION_OFFSER
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Signal Callbacks ------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/character_spawner.gd
+++ b/scenes/worlds/procedural_world/character_spawner.gd
@@ -1,9 +1,6 @@
-tool
 class_name CharacterSpawner
 extends Node
 
-
-export var character_scene : PackedScene
 
 # Represents the possible character loadouts, with the following structure:
 # Loadout:
@@ -42,19 +39,12 @@ export var character_scene : PackedScene
 #
 export(Array, Dictionary) var character_loadout : Array
 
-export var max_count = 5
-
 var data : WorldData
 
 onready var characters_root = Node.new()
 
 var _rng := RandomNumberGenerator.new()
 
-var _density_by_type := {
-	WorldData.CellType.ROOM: 0.01,
-	WorldData.CellType.CORRIDOR: 0.0025,
-	WorldData.CellType.HALL: 0.005,
-}
 var _total_weights_by_set := []
 
 
@@ -76,32 +66,16 @@ func _ready():
 func spawn_characters():
 	for child in characters_root.get_children():
 		child.queue_free()
-	var count = 0
+	
 	print("Spawning characters")
+	var characters_by_index := data.get_characters_to_spawn()
+	for cell_index in characters_by_index:
+		var spawn_data := characters_by_index[cell_index] as CharacterSpawnData
+		var cell_coordinates := data.get_local_cell_position(cell_index)
+		var character := spawn_data.spawn_character_in(characters_root)
+		_set_random_loadout(character)
 	
-	var valid_cells := []
-	for type in _density_by_type.keys():
-		valid_cells.append_array(data.get_cells_for(type))
-	valid_cells.sort()
-	
-	for cell_index in valid_cells:
-		if count >= max_count:
-			break
-		
-		var cell_type = data.get_cell_type(cell_index)
-		if _rng.randf() < _density_by_type[cell_type]:
-			count += 1
-			_spawn_character_at(cell_index)
-	
-	print("Total Characters Spawned: %s"%[count])
-
-
-func _spawn_character_at(cell_index: int) -> void:
-	var character = character_scene.instance() as Spatial
-	var cell_coordinates := data.get_local_cell_position(cell_index)
-	character.translation = cell_coordinates
-	characters_root.add_child(character)
-	_set_random_loadout(character)
+	print("Total Characters Spawned: %s"%[characters_by_index.size()])
 
 
 func _set_random_loadout(character: Spatial) -> void:
@@ -157,82 +131,3 @@ func _on_ProceduralWorld_generation_finished():
 	
 	data = owner.world_data
 	call_deferred("spawn_characters")
-
-
-###################################################################################################
-### Editor Code ###################################################################################
-###################################################################################################
-
-const GROUP_PREFIX_DENSITY = "density_"
-const PERCENT_CONVERSION = 100.0
-
-
-func _get_property_list() -> Array:
-	var properties := [
-		{
-			name = "_density_by_type",
-			type = TYPE_DICTIONARY,
-			usage = PROPERTY_USAGE_STORAGE,
-		},
-		{
-			name = "Density by Cell Type",
-			type = TYPE_NIL,
-			usage = PROPERTY_USAGE_GROUP,
-			hint_string = GROUP_PREFIX_DENSITY
-		},
-	]
-	
-	for type in ["room", "corridor", "hall"]:
-		properties.append({
-			name = GROUP_PREFIX_DENSITY + type,
-			type = TYPE_REAL,
-			usage = PROPERTY_USAGE_EDITOR,
-			hint = PROPERTY_HINT_RANGE,
-			hint_string = "0.0,100.0,0.05"
-		})
-	
-	return properties
-
-
-func _get(property: String):
-	var value
-	
-	if property.begins_with(GROUP_PREFIX_DENSITY):
-		var type := property.replace(GROUP_PREFIX_DENSITY, "")
-		match type:
-			"room":
-				value = _density_by_type[WorldData.CellType.ROOM] * PERCENT_CONVERSION
-			"corridor":
-				value = _density_by_type[WorldData.CellType.CORRIDOR] * PERCENT_CONVERSION
-			"hall":
-				value = _density_by_type[WorldData.CellType.HALL] * PERCENT_CONVERSION
-			_:
-				push_error("Unindentified density type: %s"%[type])
-	
-	return value
-
-
-func _set(property: String, value) -> bool:
-	var has_handled = false
-	
-	if property.begins_with(GROUP_PREFIX_DENSITY):
-		var type := property.replace(GROUP_PREFIX_DENSITY, "")
-		var index := -1
-		match type:
-			"room":
-				index = WorldData.CellType.ROOM
-			"corridor":
-				index = WorldData.CellType.CORRIDOR
-			"hall":
-				index = WorldData.CellType.HALL
-			_:
-				push_error("Unindentified density type: %s"%[type])
-		
-		if index > -1:
-			var final_value = value / PERCENT_CONVERSION
-			_density_by_type[index] = final_value
-			has_handled = true
-	
-	return has_handled
-
-### END of Editor Code ############################################################################

--- a/scenes/worlds/procedural_world/generate_starting_room.gd
+++ b/scenes/worlds/procedural_world/generate_starting_room.gd
@@ -1,0 +1,84 @@
+# Write your doc string for this file here
+extends GenerationStep
+
+### Member Variables and Dependencies -------------------------------------------------------------
+#--- signals --------------------------------------------------------------------------------------
+
+#--- enums ----------------------------------------------------------------------------------------
+
+#--- constants ------------------------------------------------------------------------------------
+
+#--- public variables - order: export > normal var > onready --------------------------------------
+
+export var single_tile_width := 4
+export var single_tile_height := 4
+export var player_offset := Vector2.ONE
+
+#--- private variables - order: export > normal var > onready -------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Built-in Virtual Overrides --------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Public Methods --------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+# Randomly generates the starting room, and add it to an array of Rect2 into gen_data, 
+# under the key ROOM_ARRAY_KEY
+func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
+	_generate_rooms(data, gen_data, generation_seed)
+	_fill_map_data(data, gen_data)
+
+
+func _generate_rooms(data : WorldData, gen_data : Dictionary, generation_seed : int):
+	var random : RandomNumberGenerator = RandomNumberGenerator.new()
+	random.seed = generation_seed
+	
+	var rooms: Array = gen_data[ROOM_ARRAY_KEY] if gen_data.has(ROOM_ARRAY_KEY) else Array()
+	rooms.append(_gen_starting_room_rect(data, random))
+	
+	gen_data[ROOM_ARRAY_KEY] = rooms
+
+
+func _gen_starting_room_rect(data : WorldData, random : RandomNumberGenerator) -> Rect2:
+	var value := Rect2()
+	
+	var p_x = random.randi_range(1, data.get_size_x() - 1 - single_tile_width)
+	var p_z = random.randi_range(1, data.get_size_z() - 1 - single_tile_height)
+	
+	value = Rect2(p_x, p_z, single_tile_width, single_tile_height)
+	return value
+
+
+func _fill_map_data(data : WorldData, gen_data : Dictionary):
+	var rooms : Array = gen_data.get(ROOM_ARRAY_KEY) as Array
+	
+	var starting_room := rooms[0] as Rect2
+	_fill_room_data(data, starting_room, data.CellType.ROOM, "starting_room")
+	data.player_spawn_position = starting_room.position + player_offset
+
+
+func _fill_room_data(data: WorldData, room: Rect2, cell_type: int, p_type: String) -> void:
+	var room_data := RoomData.new(p_type, room)
+	data.set_room(p_type, room_data)
+	for x in range(room.position.x, room.end.x):
+		for y in range(room.position.y, room.end.y):
+			var i = data.get_cell_index_from_int_position(x, y)
+			data.set_cell_type(i, cell_type)
+			data.clear_cell_meta(i)
+			room_data.add_cell_index(i)
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Signal Callbacks ------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/item_spawner.gd
+++ b/scenes/worlds/procedural_world/item_spawner.gd
@@ -38,7 +38,7 @@ func _spawn_world_data_objects(data: WorldData) -> void:
 	var objects_to_spawn := data.get_objects_to_spawn()
 	for cell_index in objects_to_spawn:
 		var spawn_data := objects_to_spawn[cell_index] as SpawnData
-		spawn_data.spawn_item_in(owner, true)
+		spawn_data.spawn_item_in(owner)
 
 
 func _spawn_initial_settings_items(data : WorldData):

--- a/scenes/worlds/procedural_world/item_spawner.gd
+++ b/scenes/worlds/procedural_world/item_spawner.gd
@@ -7,13 +7,6 @@ extends Node
 
 const ITEM_POSITION_OFFSET = Vector3(0.75, 1.0, 0.75)
 
-# TODO: I've put this here like this just to be able to test the changes to spawning character 
-# in a starting room. It will probably be best to move this to the world settings, with a setting
-# for "initial light" separate from the equipments settings, and wich gives as choice one of the
-# available lights. Until then, just change this export var to change the initial light available
-# for the player
-export var starting_light: PackedScene
-
 var free_cell = 0
 
 var _rng := RandomNumberGenerator.new()
@@ -37,7 +30,6 @@ func _on_ProceduralWorld_generation_finished() -> void:
 		_rng.seed = setting_generation_seed
 	
 	var data := owner.world_data as WorldData
-	_spawn_starting_light(data)
 	_spawn_initial_settings_items(data)
 	_spawn_world_data_objects(data)
 
@@ -47,21 +39,6 @@ func _spawn_world_data_objects(data: WorldData) -> void:
 	for cell_index in objects_to_spawn:
 		var spawn_data := objects_to_spawn[cell_index] as SpawnData
 		spawn_data.spawn_item_in(owner, true)
-
-
-# This calculates the center position of the cell and then tries to find a random position 
-# around it
-func _get_random_position_in_cell(
-		cell_position: Vector3, min_radius: float, max_radius: float, angle: float
-) -> Vector3:
-	var center_position := cell_position + ITEM_POSITION_OFFSET
-	
-	var radius := _rng.randf_range(min_radius, max_radius)
-	var random_direction := Vector3(cos(angle), 0.0, sin(angle)).normalized()
-	var polar_coordinate := random_direction * radius
-	
-	var value := center_position + polar_coordinate
-	return value
 
 
 func _spawn_initial_settings_items(data : WorldData):
@@ -120,23 +97,5 @@ func _spawn_tiny_item(item_data_path: String, amount: int, position: Vector3) ->
 	item.item_data = load(item_data_path)
 	item.translation = position
 	owner.add_child(item)
-
-
-func _spawn_starting_light(data : WorldData) -> void:
-	if starting_light == null:
-		return
-	
-	var starting_room := data.get_starting_room_data()
-	var starting_cells = starting_room.cell_indexes
-	if data.is_spawn_position_valid():
-		var player_index := data.get_player_spawn_position_as_index()
-		starting_cells.erase(player_index)
-	
-	var random_cell_index := _rng.randi() % starting_cells.size() as int
-	var spawn_cell = starting_cells[random_cell_index]
-	_used_cell_indexes.append(spawn_cell)
-	
-	var local_pos = data.get_local_cell_position(spawn_cell) + ITEM_POSITION_OFFSET
-	_spawn_item(starting_light.resource_path, local_pos)
 
 ### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/procedural_world/item_spawner.gd
+++ b/scenes/worlds/procedural_world/item_spawner.gd
@@ -46,8 +46,7 @@ func _spawn_world_data_objects(data: WorldData) -> void:
 	var objects_to_spawn := data.get_objects_to_spawn()
 	for cell_index in objects_to_spawn:
 		var spawn_data := objects_to_spawn[cell_index] as SpawnData
-		for _i in spawn_data.amount:
-			spawn_data.spawn_item_in(owner)
+		spawn_data.spawn_item_in(owner, true)
 
 
 # This calculates the center position of the cell and then tries to find a random position 

--- a/scenes/worlds/procedural_world/object_spawn_list.gd
+++ b/scenes/worlds/procedural_world/object_spawn_list.gd
@@ -15,18 +15,15 @@ var _current_max_amounts := []
 
 var _current_total_weight := 0
 
-var _rng: RandomNumberGenerator = null
-
-
 ### Public Methods --------------------------------------------------------------------------------
 
-func get_random_spawn_data() -> SpawnData:
+func get_random_spawn_data(rng: RandomNumberGenerator) -> SpawnData:
 	var spawn_data: SpawnData = SpawnData.new()
 	
 	if _current_paths.empty():
 		_initialize_current_arrays()
 	
-	var random_value = randi() % _current_total_weight
+	var random_value = rng.randi() % _current_total_weight
 	var index := 0
 	for value in _current_weights:
 		var weight := value as int
@@ -37,7 +34,7 @@ func get_random_spawn_data() -> SpawnData:
 			index += 1
 	
 	spawn_data.scene_path = _current_paths[index]
-	spawn_data.amount = _rng.randi_range(_current_min_amounts[index], _current_max_amounts[index])
+	spawn_data.amount = rng.randi_range(_current_min_amounts[index], _current_max_amounts[index])
 	
 	_exclude_used_index(index)
 	_current_total_weight = _calculate_total_weight()
@@ -54,8 +51,6 @@ func _initialize_current_arrays() -> void:
 	_current_weights = _weights.duplicate()
 	_current_min_amounts = _min_amounts.duplicate()
 	_current_max_amounts = _max_amounts.duplicate()
-	_rng = RandomNumberGenerator.new()
-	_rng.randomize()
 	
 	_current_total_weight = _calculate_total_weight()
 

--- a/scenes/worlds/procedural_world/procedural_world.tscn
+++ b/scenes/worlds/procedural_world/procedural_world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=22 format=2]
 
 [ext_resource path="res://scenes/worlds/game_world.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/worlds/procedural_world/procedural_world.gd" type="Script" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd" type="Script" id=11]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/candelabra_spawn_list.tres" type="Resource" id=12]
 [ext_resource path="res://scenes/worlds/procedural_world/generate_starting_room.gd" type="Script" id=13]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd" type="Script" id=14]
 [ext_resource path="res://scenes/worlds/procedural_world/item_spawner.gd" type="Script" id=16]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_rooms.gd" type="Script" id=17]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_walls.gd" type="Script" id=18]
@@ -96,12 +97,15 @@ script = ExtResource( 10 )
 script = ExtResource( 11 )
 _spawn_list_resource = ExtResource( 12 )
 
-[node name="ItemSpawner" type="Node" parent="." index="7"]
-script = ExtResource( 16 )
-starting_light = ExtResource( 7 )
+[node name="GenerateInitialLoot" type="Node" parent="GenerationManager/PopulateRooms" index="1"]
+script = ExtResource( 14 )
 _loot_list_resource = ExtResource( 8 )
 _min_loot = 10
 _max_loot = 15
+
+[node name="ItemSpawner" type="Node" parent="." index="7"]
+script = ExtResource( 16 )
+starting_light = ExtResource( 7 )
 
 [connection signal="generation_finished" from="." to="CharacterSpawner" method="_on_ProceduralWorld_generation_finished"]
 [connection signal="generation_finished" from="." to="ItemSpawner" method="_on_ProceduralWorld_generation_finished"]

--- a/scenes/worlds/procedural_world/procedural_world.tscn
+++ b/scenes/worlds/procedural_world/procedural_world.tscn
@@ -102,10 +102,10 @@ script = ExtResource( 14 )
 _loot_list_resource = ExtResource( 8 )
 _min_loot = 10
 _max_loot = 15
+_path_starting_light_scene = "res://scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn"
 
 [node name="ItemSpawner" type="Node" parent="." index="7"]
 script = ExtResource( 16 )
-starting_light = ExtResource( 7 )
 
 [connection signal="generation_finished" from="." to="CharacterSpawner" method="_on_ProceduralWorld_generation_finished"]
 [connection signal="generation_finished" from="." to="ItemSpawner" method="_on_ProceduralWorld_generation_finished"]

--- a/scenes/worlds/procedural_world/procedural_world.tscn
+++ b/scenes/worlds/procedural_world/procedural_world.tscn
@@ -1,12 +1,10 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://scenes/worlds/game_world.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/worlds/procedural_world/procedural_world.gd" type="Script" id=2]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_room_graph.gd" type="Script" id=3]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd" type="Script" id=4]
 [ext_resource path="res://resources/mesh_libraries/modular_pieces.meshlib" type="MeshLibrary" id=5]
-[ext_resource path="res://scenes/characters/cultists/neophyte.tscn" type="PackedScene" id=6]
-[ext_resource path="res://scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn" type="PackedScene" id=7]
 [ext_resource path="res://scenes/worlds/procedural_world/initial_loot_list.tres" type="Resource" id=8]
 [ext_resource path="res://scenes/worlds/procedural_world/character_spawner.gd" type="Script" id=9]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generation_group.gd" type="Script" id=10]
@@ -14,6 +12,7 @@
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/candelabra_spawn_list.tres" type="Resource" id=12]
 [ext_resource path="res://scenes/worlds/procedural_world/generate_starting_room.gd" type="Script" id=13]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd" type="Script" id=14]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/generation_cultists.gd" type="Script" id=15]
 [ext_resource path="res://scenes/worlds/procedural_world/item_spawner.gd" type="Script" id=16]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_rooms.gd" type="Script" id=17]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_walls.gd" type="Script" id=18]
@@ -39,16 +38,6 @@ directional_shadow_normal_bias = 0.2
 
 [node name="Navigation" parent="." index="4"]
 preview_material = SubResource( 3 )
-
-[node name="CharacterSpawner" type="Node" parent="." index="5"]
-script = ExtResource( 9 )
-character_scene = ExtResource( 6 )
-max_count = 3
-_density_by_type = {
-2: 0.02,
-3: 0.0025,
-4: 0.005
-}
 
 [node name="GenerateStartingRoom" type="Node" parent="GenerationManager" index="0"]
 script = ExtResource( 13 )
@@ -104,8 +93,20 @@ _min_loot = 10
 _max_loot = 15
 _path_starting_light_scene = "res://scenes/objects/pickable_items/equipment/tool/light-sources/omnidirectional_lantern/omni_lantern.tscn"
 
-[node name="ItemSpawner" type="Node" parent="." index="7"]
+[node name="GenerationCultists" type="Node" parent="GenerationManager/PopulateRooms" index="2"]
+script = ExtResource( 15 )
+_character_scene_path = "res://scenes/characters/cultists/neophyte.tscn"
+_density_by_type = {
+1: 0.005,
+2: 0.0025,
+3: 0
+}
+
+[node name="ItemSpawner" type="Node" parent="." index="6"]
 script = ExtResource( 16 )
 
-[connection signal="generation_finished" from="." to="CharacterSpawner" method="_on_ProceduralWorld_generation_finished"]
+[node name="CharacterSpawner" type="Node" parent="." index="7"]
+script = ExtResource( 9 )
+
 [connection signal="generation_finished" from="." to="ItemSpawner" method="_on_ProceduralWorld_generation_finished"]
+[connection signal="generation_finished" from="." to="CharacterSpawner" method="_on_ProceduralWorld_generation_finished"]

--- a/scenes/worlds/procedural_world/procedural_world.tscn
+++ b/scenes/worlds/procedural_world/procedural_world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://scenes/worlds/game_world.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/worlds/procedural_world/procedural_world.gd" type="Script" id=2]
@@ -12,13 +12,13 @@
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generation_group.gd" type="Script" id=10]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd" type="Script" id=11]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/populate_room/candelabra_spawn_list.tres" type="Resource" id=12]
+[ext_resource path="res://scenes/worlds/procedural_world/generate_starting_room.gd" type="Script" id=13]
 [ext_resource path="res://scenes/worlds/procedural_world/item_spawner.gd" type="Script" id=16]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_rooms.gd" type="Script" id=17]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_walls.gd" type="Script" id=18]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_halls.gd" type="Script" id=19]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_corridors.gd" type="Script" id=20]
 [ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_grid_tiles.gd" type="Script" id=21]
-
 
 [sub_resource type="SpatialMaterial" id=3]
 flags_unshaded = true
@@ -49,27 +49,30 @@ _density_by_type = {
 4: 0.005
 }
 
-[node name="GenerateRooms" type="Node" parent="GenerationManager" index="0"]
+[node name="GenerateStartingRoom" type="Node" parent="GenerationManager" index="0"]
+script = ExtResource( 13 )
+
+[node name="GenerateRooms" type="Node" parent="GenerationManager" index="1"]
 script = ExtResource( 17 )
 room_size_max = 3
 
-[node name="GenerateRoomGraph" type="Node" parent="GenerationManager" index="1"]
+[node name="GenerateRoomGraph" type="Node" parent="GenerationManager" index="2"]
 script = ExtResource( 3 )
 
-[node name="GenerateCorridors" type="Node" parent="GenerationManager" index="2"]
+[node name="GenerateCorridors" type="Node" parent="GenerationManager" index="3"]
 script = ExtResource( 20 )
 
-[node name="GenerateHalls" type="Node" parent="GenerationManager" index="3"]
+[node name="GenerateHalls" type="Node" parent="GenerationManager" index="4"]
 script = ExtResource( 19 )
 
-[node name="GenerateWalls" type="Node" parent="GenerationManager" index="4"]
+[node name="GenerateWalls" type="Node" parent="GenerationManager" index="5"]
 script = ExtResource( 18 )
 
-[node name="GenerateRoomPillars" type="Node" parent="GenerationManager" index="5"]
+[node name="GenerateRoomPillars" type="Node" parent="GenerationManager" index="6"]
 script = ExtResource( 4 )
 pillar_tile = 16
 
-[node name="GenerateGridTiles" type="Node" parent="GenerationManager" index="6"]
+[node name="GenerateGridTiles" type="Node" parent="GenerationManager" index="7"]
 script = ExtResource( 21 )
 floor_tile = 6
 wall_tile = 5
@@ -83,7 +86,7 @@ pillar_room_double_floor_tile = 7
 pillar_room_pillar_tile = 15
 pillar_tile = 16
 
-[node name="PopulateRooms" type="Node" parent="GenerationManager" index="7"]
+[node name="PopulateRooms" type="Node" parent="GenerationManager" index="8"]
 script = ExtResource( 10 )
 
 [node name="IlluminationGroup" type="Node" parent="GenerationManager/PopulateRooms" index="0"]

--- a/scenes/worlds/procedural_world/spawn_data.gd
+++ b/scenes/worlds/procedural_world/spawn_data.gd
@@ -1,4 +1,5 @@
 # Helper class for spawning objects
+tool
 class_name SpawnData
 extends Resource
 
@@ -14,10 +15,11 @@ const CENTER_POSITION_OFFSET = Vector3(0.75, 1.0, 0.75)
 #--- public variables - order: export > normal var > onready --------------------------------------
 
 export var scene_path: String = ""
-export var amount: int = 1
-export var transform := Transform.IDENTITY
+export var amount: int = 1 setget _set_amount
 
 #--- private variables - order: export > normal var > onready -------------------------------------
+
+export var _transforms: Array
 
 ### -----------------------------------------------------------------------------------------------
 
@@ -34,21 +36,29 @@ func _to_string() -> String:
 ### Public Methods --------------------------------------------------------------------------------
 
 func spawn_item_in(node: Node, should_log := false) -> void:
-	var item
 	var item_scene : PackedScene = load(scene_path)
-	item = item_scene.instance()
-	if item is Spatial:
-		item.transform = transform
+	for index in amount:
+		var item = item_scene.instance()
+		if item is Spatial:
+			item.transform = _transforms[index]
+		
+		node.add_child(item, true)
+		if should_log:
+			print("item spawned: %s | at: %s | rotated by: %s"%[
+					scene_path, _transforms[index].origin, _transforms[index].basis.get_euler()
+			])
+
+
+func set_center_position_in_cell(cell_position: Vector3, instance_index := INF) -> void:
+	if amount > 1 and instance_index == INF:
+		push_warning("Setting the smae position for multiple item instances")
 	
-	node.add_child(item, true)
-	if should_log:
-		print("item spawned: %s | at: %s | rotated by: %s"%[
-				scene_path, transform.origin, transform.basis.get_euler()
-		])
-
-
-func set_center_position_in_cell(cell_position: Vector3) -> void:
-	transform = transform.translated(cell_position + CENTER_POSITION_OFFSET)
+	for i in amount:
+		if instance_index != INF and i != instance_index:
+			continue
+		
+		var transform := Transform.IDENTITY.translated(cell_position + CENTER_POSITION_OFFSET)
+		_transforms[i] = transform
 
 
 # This calculates the center position of the cell and then tries to find a random position 
@@ -58,36 +68,71 @@ func set_random_position_in_cell(
 		cell_position: Vector3, 
 		min_radius: float, 
 		max_radius: float, 
-		angle := INF
+		p_angle := INF,
+		instance_index := INF
 ) -> void:
-	var center_position := cell_position + CENTER_POSITION_OFFSET
-	if angle == INF:
-		angle = rng.randf_range(0.0, TAU)
+	if p_angle != INF and instance_index == INF:
+		push_warning("Setting the same position for multiple item instances")
 	
-	var radius := rng.randf_range(min_radius, max_radius)
-	var random_direction := Vector3(cos(angle), 0.0, sin(angle)).normalized()
-	var polar_coordinate := random_direction * radius
-	
-	var random_position := center_position + polar_coordinate
-	transform = transform.translated(random_position)
+	for i in amount:
+		if instance_index != INF and i != instance_index:
+			continue
+		
+		var transform := _transforms[i] as Transform
+		var angle := p_angle
+		var center_position := cell_position + CENTER_POSITION_OFFSET
+		
+		if angle == INF:
+			angle = rng.randf_range(0.0, TAU)
+			print("angle #%s: %s"%[i, angle])
+		
+		var radius := rng.randf_range(min_radius, max_radius)
+		var random_direction := Vector3(cos(angle), 0.0, sin(angle)).normalized()
+		var polar_coordinate := random_direction * radius
+		var random_position := center_position + polar_coordinate
+		transform = transform.translated(random_position)
+		transform.basis = transform.basis.rotated(Vector3.UP, angle)
+		_transforms[i] = transform
 
 
-func set_random_rotation_in_all_axis(rng: RandomNumberGenerator) -> void:
-	var random_rotation = Quat(Vector3(
-		rng.randf_range(0, TAU),
-		rng.randf_range(0, TAU),
-		rng.randf_range(0, TAU)
-	))
-	transform.basis = Basis(random_rotation)
+func set_random_rotation_in_all_axis(rng: RandomNumberGenerator, instance_index := INF) -> void:
+	for i in amount:
+		if instance_index != INF and i != instance_index:
+			continue
+		
+		var transform = _transforms[i] as Transform
+		var random_rotation = Quat(Vector3(
+			rng.randf_range(0, TAU),
+			rng.randf_range(0, TAU),
+			rng.randf_range(0, TAU)
+		))
+		transform.basis = Basis(random_rotation)
+		_transforms[i] = transform
 
 
-func set_y_rotation(angle_rad: float) -> void:
-	transform.basis = transform.basis.rotated(Vector3.UP, angle_rad)
+func set_y_rotation(angle_rad: float, instance_index := INF) -> void:
+	for i in amount:
+		if instance_index != INF and i != instance_index:
+			continue
+		
+		var transform = _transforms[i] as Transform
+		transform.basis = transform.basis.rotated(Vector3.UP, angle_rad)
+		_transforms[i] = transform
 
 ### -----------------------------------------------------------------------------------------------
 
 
 ### Private Methods -------------------------------------------------------------------------------
+
+func _set_amount(value: int) -> void:
+	amount = max(1, value)
+	var old_tranforms = _transforms.duplicate()
+	_transforms.resize(amount)
+	_transforms.fill(Transform.IDENTITY)
+	
+	for index in _transforms.size():
+		if index < old_tranforms.size() and _transforms[index] != old_tranforms[index]:
+			_transforms[index] = old_tranforms[index]
 
 ### -----------------------------------------------------------------------------------------------
 

--- a/scenes/worlds/procedural_world/spawn_data.gd
+++ b/scenes/worlds/procedural_world/spawn_data.gd
@@ -10,7 +10,7 @@ extends Resource
 
 #--- constants ------------------------------------------------------------------------------------
 
-const CENTER_POSITION_OFFSET = Vector3(0.75, 1.0, 0.75)
+const ITEM_CENTER_POSITION_OFFSET = Vector3(0.75, 1.0, 0.75)
 
 #--- public variables - order: export > normal var > onready --------------------------------------
 
@@ -31,7 +31,9 @@ func _init() -> void:
 
 
 func _to_string() -> String:
-	var msg := "[SpawnData:%s | amount: %s scene_path: %s]"%[get_instance_id(), amount, scene_path]
+	var msg := "[SpawnData:%s | amount: %s scene_path: %s tranforms: %s]"%[
+			get_instance_id(), amount, scene_path, _transforms
+	]
 	return msg
 
 ### -----------------------------------------------------------------------------------------------
@@ -61,7 +63,7 @@ func set_center_position_in_cell(cell_position: Vector3, instance_index := INF) 
 		if instance_index != INF and i != instance_index:
 			continue
 		
-		var transform := Transform.IDENTITY.translated(cell_position + CENTER_POSITION_OFFSET)
+		var transform := Transform.IDENTITY.translated(cell_position + _get_center_offset())
 		_transforms[i] = transform
 
 
@@ -84,7 +86,7 @@ func set_random_position_in_cell(
 		
 		var transform := _transforms[i] as Transform
 		var angle := p_angle
-		var center_position := cell_position + CENTER_POSITION_OFFSET
+		var center_position := cell_position + _get_center_offset()
 		
 		if angle == INF:
 			angle = rng.randf_range(0.0, TAU)
@@ -137,6 +139,10 @@ func _set_amount(value: int) -> void:
 	for index in _transforms.size():
 		if index < old_tranforms.size() and _transforms[index] != old_tranforms[index]:
 			_transforms[index] = old_tranforms[index]
+
+
+func _get_center_offset() -> Vector3:
+	return ITEM_CENTER_POSITION_OFFSET
 
 ### -----------------------------------------------------------------------------------------------
 

--- a/scenes/worlds/procedural_world/spawn_data.gd
+++ b/scenes/worlds/procedural_world/spawn_data.gd
@@ -90,7 +90,6 @@ func set_random_position_in_cell(
 		
 		if angle == INF:
 			angle = rng.randf_range(0.0, TAU)
-			print("angle #%s: %s"%[i, angle])
 		
 		var radius := rng.randf_range(min_radius, max_radius)
 		var random_direction := Vector3(cos(angle), 0.0, sin(angle)).normalized()

--- a/scenes/worlds/procedural_world/spawn_data.gd
+++ b/scenes/worlds/procedural_world/spawn_data.gd
@@ -26,6 +26,10 @@ export var _transforms: Array
 
 ### Built-in Virtual Overrides --------------------------------------------------------------------
 
+func _init() -> void:
+	_set_amount(1)
+
+
 func _to_string() -> String:
 	var msg := "[SpawnData:%s | amount: %s scene_path: %s]"%[get_instance_id(), amount, scene_path]
 	return msg

--- a/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
@@ -18,12 +18,12 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 	pass
 
 
-func get_cell_mask(data : WorldData, cells : Array) -> int:
+func get_cell_mask(data : WorldData, cells : Array, value: int) -> int:
 	var mask = 0b0000
-	mask = mask | 0b0001*int(data.is_room_cell(cells[0]))
-	mask = mask | 0b0010*int(data.is_room_cell(cells[1]))
-	mask = mask | 0b0100*int(data.is_room_cell(cells[2]))
-	mask = mask | 0b1000*int(data.is_room_cell(cells[3]))
+	mask = mask | 0b0001*int(data.get_cell_type(cells[0]) == value)
+	mask = mask | 0b0010*int(data.get_cell_type(cells[1]) == value)
+	mask = mask | 0b0100*int(data.get_cell_type(cells[2]) == value)
+	mask = mask | 0b1000*int(data.get_cell_type(cells[3]) == value)
 	return mask
 
 
@@ -37,7 +37,7 @@ func generate_double_a_star_grid(data : WorldData) -> AStar2D:
 				data.get_cell_index_from_int_position(x, z),
 				data.get_cell_index_from_int_position(x - 1, z),
 			]
-			var room_mask = get_cell_mask(data, cells)
+			var room_mask = get_cell_mask(data, cells, data.CellType.ROOM)
 			var p : Vector2 = Vector2(x, z)
 			
 			var w = 1.0
@@ -112,7 +112,7 @@ func generate_double_corridor(data : WorldData, astar : AStar2D, a : int, b : in
 				data.get_cell_index_from_int_position(x - 1, z),
 			]
 		# room mask as 3210 (clockwise order from lower bit)
-		var rooms = get_cell_mask(data, cells)
+		var rooms = get_cell_mask(data, cells, data.CellType.ROOM)
 		
 		var is_edge = false
 		var is_room = false

--- a/scenes/worlds/world_gen/generation_steps/generate_grid_tiles.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_grid_tiles.gd
@@ -35,7 +35,7 @@ func select_floor_tiles(data : WorldData, pillar_rooms : Array):
 		var cell_type = data.get_cell_type(i)
 		var is_pillar_room = data.get_cell_meta(i, data.CellMetaKeys.META_PILLAR_ROOM, false)
 		if cell_type != data.CellType.EMPTY and not is_pillar_room:
-			if cell_type == data.CellType.ROOM or cell_type == data.CellType.STARTING_ROOM:
+			if cell_type == data.CellType.ROOM:
 				data.set_cell_surfacetype(i, data.SurfaceType.STONE)
 			elif cell_type == data.CellType.CORRIDOR:
 				data.set_cell_surfacetype(i, data.SurfaceType.CARPET)

--- a/scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd
@@ -29,7 +29,7 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 	# on the room_rects array as a Rect2, and an array of the cells belonging
 	# to each room is stored on the cells_in_room array
 	for i in data.cell_count:
-		if room_index[i] == 0 and data.is_room_cell(i):
+		if room_index[i] == 0 and data.get_cell_type(i) == data.CellType.ROOM:
 			var queue = Array()
 			queue.push_back(i)
 			var queue_index = 0
@@ -45,7 +45,10 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 				room_rect = room_rect.merge(cell_rect)
 				for dir in data.Direction.size():
 					var neighbour = data.get_neighbour_cell(cell, dir)
-					if room_index[neighbour] == 0 and data.is_room_cell(neighbour):
+					if (
+							room_index[neighbour] == 0 
+							and data.get_cell_type(neighbour) == data.CellType.ROOM
+					):
 						room_index[neighbour] = current_room_index
 						queue.push_back(neighbour)
 				queue_index += 1

--- a/scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd
@@ -138,7 +138,7 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 		for cell in cell_list:
 			data.set_cell_meta(cell, data.CellMetaKeys.META_PILLAR_ROOM, true)
 		pillar_rooms.push_back(room_rect)
-		print(pillar_rooms)
+		print("pillar rooms: %s"%[pillar_rooms])
 #		var cells_with_pillar : Dictionary = Dictionary()
 #		for cell in cells_in_room[room]:
 #			var cell_coords = data.get_int_position_from_cell_index(cell)

--- a/scenes/worlds/world_gen/generation_steps/generate_rooms.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_rooms.gd
@@ -1,12 +1,5 @@
 extends GenerationStep
 
-
-const ROOM_ARRAY_KEY = "rooms"
-
-export var starting_room_columns := 3
-export var starting_room_rows := 3
-export var starting_room_player_offset := Vector2.ONE
-
 export var room_size_min : int = 1
 export var room_size_max : int = 4
 
@@ -42,7 +35,7 @@ func generate_rooms(data : WorldData, gen_data : Dictionary, generation_seed : i
 	var rooms : Array = gen_data[ROOM_ARRAY_KEY] if gen_data.has(ROOM_ARRAY_KEY) else Array()
 	var room_try_count : int = random.randi_range(room_count_min, room_count_max)
 	for i in room_try_count:
-		var room : Rect2 = _gen_room_rect(data, random, i == 0)
+		var room : Rect2 = _gen_room_rect(data, random)
 		var intersection_test = room.grow(room_min_distance)
 		var intersecting_rooms = Array()
 		for _r in rooms:
@@ -76,10 +69,6 @@ func check_room_space(data : WorldData, room : Rect2) -> bool:
 func fill_map_data(data : WorldData, gen_data : Dictionary):
 	var rooms : Array = gen_data.get(ROOM_ARRAY_KEY) as Array
 	
-	var starting_room := rooms[0] as Rect2
-	_fill_room_data(data, starting_room, data.CellType.STARTING_ROOM, "starting_room")
-	data.player_spawn_position = starting_room.position + starting_room_player_offset
-	
 	for index in range(1, rooms.size()):
 		var room : Rect2 = rooms[index] as Rect2
 		_fill_room_data(data, room, data.CellType.ROOM, "generic")
@@ -96,23 +85,15 @@ func _fill_room_data(data: WorldData, room: Rect2, cell_type: int, p_type: Strin
 			room_data.add_cell_index(i)
 
 
-func _gen_room_rect(
-		data : WorldData, random : RandomNumberGenerator, is_starting_room := false
-) -> Rect2:
+func _gen_room_rect(data : WorldData, random : RandomNumberGenerator) -> Rect2:
 	var value := Rect2()
 	
-	if is_starting_room:
-		var p_x = random.randi_range(1, data.get_size_x() - 1 - starting_room_columns)
-		var p_z = random.randi_range(1, data.get_size_z() - 1 - starting_room_rows)
-		
-		value = Rect2(p_x, p_z, starting_room_columns, starting_room_rows)
-	else:
-		var s_x = int(random.randi_range(actual_room_min, actual_room_max)*room_size_scale)
-		var s_z = int(random.randi_range(actual_room_min, actual_room_max)*room_size_scale)
-		
-		var p_x = random.randi_range(1, data.get_size_x() - 1 - s_x)
-		var p_z = random.randi_range(1, data.get_size_z() - 1 - s_z)
-		
-		value = Rect2(p_x, p_z, s_x, s_z)
+	var s_x = int(random.randi_range(actual_room_min, actual_room_max)*room_size_scale)
+	var s_z = int(random.randi_range(actual_room_min, actual_room_max)*room_size_scale)
+	
+	var p_x = random.randi_range(1, data.get_size_x() - 1 - s_x)
+	var p_z = random.randi_range(1, data.get_size_z() - 1 - s_z)
+	
+	value = Rect2(p_x, p_z, s_x, s_z)
 	
 	return value

--- a/scenes/worlds/world_gen/generation_steps/generate_walls.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_walls.gd
@@ -17,7 +17,7 @@ func contour_walls(data : WorldData):
 			for dir in data.Direction.DIRECTION_MAX:
 				var other = data.get_cell_type(data.get_neighbour_cell(this, dir))
 				match data.get_cell_type(this):
-					data.CellType.ROOM, data.CellType.STARTING_ROOM:
+					data.CellType.ROOM:
 						match other:
 							data.CellType.EMPTY, data.CellType.CORRIDOR, data.CellType.HALL:
 								data.set_wall(this, dir, data.EdgeType.WALL)
@@ -25,7 +25,7 @@ func contour_walls(data : WorldData):
 								pass
 					data.CellType.CORRIDOR, data.CellType.HALL:
 						match other:
-							data.CellType.EMPTY, data.CellType.ROOM, data.CellType.STARTING_ROOM:
+							data.CellType.EMPTY, data.CellType.ROOM:
 								data.set_wall(this, dir, data.EdgeType.WALL)
 							_:
 								pass
@@ -35,7 +35,7 @@ func contour_walls(data : WorldData):
 						var s = data.get_neighbour_cell(this, data.Direction.SOUTH)
 						var w = data.get_neighbour_cell(this, data.Direction.WEST)
 						match other:
-							data.CellType.ROOM, data.CellType.STARTING_ROOM:
+							data.CellType.ROOM:
 								if data.get_cell_meta(this, data.CellMetaKeys.META_DOOR_DIRECTIONS).has(dir):
 									var extends_right = false
 									var extends_left = false

--- a/scenes/worlds/world_gen/generation_steps/generation_manager.gd
+++ b/scenes/worlds/world_gen/generation_steps/generation_manager.gd
@@ -15,6 +15,7 @@ func generate() -> WorldData:
 	var setting_generation_seed = GameManager.game.local_settings.get_setting("World Seed")
 	if setting_generation_seed is int:
 		generation_seed = setting_generation_seed
+		print("Generation Seed: %s"%[generation_seed])
 	var data : WorldData = WorldData.new()
 	data.resize(world_size_x, world_size_z)
 	

--- a/scenes/worlds/world_gen/generation_steps/generation_step.gd
+++ b/scenes/worlds/world_gen/generation_steps/generation_step.gd
@@ -1,6 +1,7 @@
 class_name GenerationStep
 extends Node
 
+const ROOM_ARRAY_KEY = "rooms"
 
 # Override this function
 func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
@@ -76,7 +76,7 @@ func _handle_candelabra(world_data: WorldData, room_data: RoomData) -> void:
 			continue
 		
 		var cell_position := world_data.get_local_cell_position(corner_index)
-		var spawn_data := spawn_list.get_random_spawn_data()
+		var spawn_data := spawn_list.get_random_spawn_data(_rng)
 		if not spawn_data.scene_path.empty():
 			spawn_data.set_center_position_in_cell(cell_position)
 			if spawn_data.scene_path.find(UNLIT_KEYWORD) != -1:

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
@@ -85,7 +85,7 @@ func _handle_candelabra(world_data: WorldData, room_data: RoomData) -> void:
 				var facing_angle := corners.get_facing_angle_for(key)
 				spawn_data.set_y_rotation(facing_angle)
 			
-			world_data.set_spawn_data_to_cell(corner_index, spawn_data)
+			world_data.set_object_spawn_data_to_cell(corner_index, spawn_data)
 		else:
 #			print("No candelabra to spawn in this corner: %s"%[corner_index])
 			pass

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generate_candelabra.gd
@@ -117,8 +117,7 @@ func _is_corner_next_to_door(
 	world_data
 	
 	for direction in corner_directions:
-		var wall_type := world_data.get_wall_type(corner_index, direction)
-		if wall_type == world_data.EdgeType.DOOR:
+		if world_data.has_door(corner_index, direction):
 			value = true
 			break
 	

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd
@@ -77,7 +77,7 @@ func _generate_initial_light_data(data: WorldData) -> void:
 	var chosen_index = starting_cells[random_cell_index]
 	var local_pos = data.get_local_cell_position(chosen_index)
 	spawn_data.set_center_position_in_cell(local_pos)
-	data.set_spawn_data_to_cell(chosen_index, spawn_data)
+	data.set_object_spawn_data_to_cell(chosen_index, spawn_data)
 
 
 func _generate_initial_loot_spawn_data(data: WorldData, loot_list: ObjectSpawnList) -> void:
@@ -104,7 +104,7 @@ func _generate_initial_loot_spawn_data(data: WorldData, loot_list: ObjectSpawnLi
 				cell_radius * _max_radius_multiplier
 		)
 		
-		data.set_spawn_data_to_cell(cell_index, spawn_data)
+		data.set_object_spawn_data_to_cell(cell_index, spawn_data)
 
 
 func _remove_used_cells_from(p_array: Array, data: WorldData) -> Array:

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generate_initial_loot.gd
@@ -1,0 +1,102 @@
+# Write your doc string for this file here
+tool
+extends GenerationStep
+
+### Member Variables and Dependencies -------------------------------------------------------------
+#--- signals --------------------------------------------------------------------------------------
+
+#--- enums ----------------------------------------------------------------------------------------
+
+#--- constants ------------------------------------------------------------------------------------
+
+#--- public variables - order: export > normal var > onready --------------------------------------
+
+#--- private variables - order: export > normal var > onready -------------------------------------
+
+export var _loot_list_resource: Resource = null
+export var _min_loot := 5 setget _set_min_loot
+export var _max_loot := 10 setget _set_max_loot
+export var _min_radius_multiplier := 0.1
+export var _max_radius_multiplier := 0.3
+
+var _rng := RandomNumberGenerator.new()
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Built-in Virtual Overrides --------------------------------------------------------------------
+
+func _ready() -> void:
+	if Engine.editor_hint:
+		return
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Public Methods --------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
+	if Engine.editor_hint:
+		return
+	elif _loot_list_resource == null or not _loot_list_resource is ObjectSpawnList:
+		push_error("No resource, or invalid resource, on _loot_list_resource property")
+		return
+	
+	_rng.seed = generation_seed
+	_generate_initial_loot_spawn_data(data, _loot_list_resource)
+
+
+func _generate_initial_loot_spawn_data(data : WorldData, loot_list: ObjectSpawnList) -> void:
+	var draw_amount := _rng.randi_range(_min_loot, _max_loot)
+	var possible_cells := data.get_cells_for(data.CellType.ROOM)
+	possible_cells = _remove_used_cells_from(possible_cells, data)
+	
+	for _i in draw_amount:
+		var spawn_data := loot_list.get_random_spawn_data(_rng)
+		
+		if possible_cells.empty():
+			return
+		
+		var lucky_index = _rng.randi() % possible_cells.size()
+		var cell_index := possible_cells[lucky_index] as int
+		possible_cells.remove(cell_index)
+		
+		var cell_position := data.get_local_cell_position(cell_index)
+		var cell_radius := data.CELL_SIZE * 0.5
+		spawn_data.set_random_position_in_cell(
+				_rng, 
+				cell_position, 
+				cell_radius * _min_radius_multiplier, 
+				cell_radius * _max_radius_multiplier
+		)
+		
+		data.set_spawn_data_to_cell(cell_index, spawn_data)
+
+
+func _remove_used_cells_from(p_array: Array, data: WorldData) -> Array:
+	for cell_index in data._objects_to_spawn.keys():
+		p_array.erase(cell_index)
+	
+	p_array.erase(data.player_spawn_position)
+	
+	return p_array
+
+
+func _set_min_loot(value: int) -> void:
+	_min_loot = clamp(value, 0, _max_loot)
+
+
+func _set_max_loot(value: int) -> void:
+	_max_loot = max(value, _min_loot)
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Signal Callbacks ------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generation_cultists.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generation_cultists.gd
@@ -1,0 +1,165 @@
+# Write your doc string for this file here
+tool
+extends GenerationStep
+
+### Member Variables and Dependencies -------------------------------------------------------------
+#--- signals --------------------------------------------------------------------------------------
+
+#--- enums ----------------------------------------------------------------------------------------
+
+#--- constants ------------------------------------------------------------------------------------
+
+#--- public variables - order: export > normal var > onready --------------------------------------
+
+#--- private variables - order: export > normal var > onready -------------------------------------
+
+export(String, FILE, "*.tscn") var _character_scene_path := ""
+export var _max_count = 5
+
+var _density_by_type := {
+	WorldData.CellType.ROOM: 0.01,
+	WorldData.CellType.CORRIDOR: 0.0025,
+	WorldData.CellType.HALL: 0.005,
+}
+
+var _rng := RandomNumberGenerator.new()
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Built-in Virtual Overrides --------------------------------------------------------------------
+
+func _ready():
+	if Engine.editor_hint:
+		return
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Public Methods --------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
+	_rng.seed = generation_seed
+	
+	var valid_cells := _get_valid_cells(data)
+	
+	var count = 0
+	for cell_index in valid_cells:
+		if count >= _max_count:
+			break
+		
+		var cell_type = data.get_cell_type(cell_index)
+		if _rng.randf() < _density_by_type[cell_type]:
+			count += 1
+			var local_position := data.get_local_cell_position(cell_index)
+			var spawn_data := CharacterSpawnData.new()
+			print("spawn_data: %s"%[spawn_data])
+			spawn_data.scene_path = _character_scene_path
+			spawn_data.set_center_position_in_cell(local_position)
+			data.set_character_spawn_data_to_cell(cell_index, spawn_data)
+
+
+func _get_valid_cells(data: WorldData) -> Array:
+	var valid_cells := []
+	for type in _density_by_type.keys():
+		valid_cells.append_array(data.get_cells_for(type))
+	valid_cells.sort()
+	
+	# Remove Starting Room cell indexes
+	var starting_room_indexes := data.get_starting_room_data().cell_indexes
+	for index in starting_room_indexes:
+		var invalid_cell_index := valid_cells.find(index)
+		if invalid_cell_index != -1:
+			valid_cells.remove(invalid_cell_index)
+	
+	return valid_cells
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Signal Callbacks ------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------
+
+###################################################################################################
+### Editor Code ###################################################################################
+###################################################################################################
+
+const GROUP_PREFIX_DENSITY = "density_"
+const PERCENT_CONVERSION = 100.0
+
+
+func _get_property_list() -> Array:
+	var properties := [
+		{
+			name = "_density_by_type",
+			type = TYPE_DICTIONARY,
+			usage = PROPERTY_USAGE_STORAGE,
+		},
+		{
+			name = "Density by Cell Type",
+			type = TYPE_NIL,
+			usage = PROPERTY_USAGE_GROUP,
+			hint_string = GROUP_PREFIX_DENSITY
+		},
+	]
+	
+	for type in ["room", "corridor", "hall"]:
+		properties.append({
+			name = GROUP_PREFIX_DENSITY + type,
+			type = TYPE_REAL,
+			usage = PROPERTY_USAGE_EDITOR,
+			hint = PROPERTY_HINT_RANGE,
+			hint_string = "0.0,100.0,0.05"
+		})
+	
+	return properties
+
+
+func _get(property: String):
+	var value
+	
+	if property.begins_with(GROUP_PREFIX_DENSITY):
+		var type := property.replace(GROUP_PREFIX_DENSITY, "")
+		match type:
+			"room":
+				value = _density_by_type[WorldData.CellType.ROOM] * PERCENT_CONVERSION
+			"corridor":
+				value = _density_by_type[WorldData.CellType.CORRIDOR] * PERCENT_CONVERSION
+			"hall":
+				value = _density_by_type[WorldData.CellType.HALL] * PERCENT_CONVERSION
+			_:
+				push_error("Unindentified density type: %s"%[type])
+	
+	return value
+
+
+func _set(property: String, value) -> bool:
+	var has_handled = false
+	
+	if property.begins_with(GROUP_PREFIX_DENSITY):
+		var type := property.replace(GROUP_PREFIX_DENSITY, "")
+		var index := -1
+		match type:
+			"room":
+				index = WorldData.CellType.ROOM
+			"corridor":
+				index = WorldData.CellType.CORRIDOR
+			"hall":
+				index = WorldData.CellType.HALL
+			_:
+				push_error("Unindentified density type: %s"%[type])
+		
+		if index > -1:
+			var final_value = value / PERCENT_CONVERSION
+			_density_by_type[index] = final_value
+			has_handled = true
+	
+	return has_handled
+
+### END of Editor Code ############################################################################

--- a/scenes/worlds/world_gen/generation_steps/populate_room/generation_cultists.gd
+++ b/scenes/worlds/world_gen/generation_steps/populate_room/generation_cultists.gd
@@ -58,7 +58,6 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 			count += 1
 			var local_position := data.get_local_cell_position(cell_index)
 			var spawn_data := CharacterSpawnData.new()
-			print("spawn_data: %s"%[spawn_data])
 			spawn_data.scene_path = _character_scene_path
 			spawn_data.set_center_position_in_cell(local_position)
 			data.set_character_spawn_data_to_cell(cell_index, spawn_data)


### PR DESCRIPTION
Refactors to:
- Remove enum value STARTING_ROOM and handle starting room in it's own GenerationStep
- Move initial loot spawn logic to its own GenerationStep
- Move intial light logic to InitialLoot Generation Step
- Move cultist spawn logic to its own GenerationStep

Along the way some bugs were found and fixed:
- ObjectSpawnList was not using world generation rng seed
- Candelabra was spawning in front of half doors