### PR TITLE
Dungeon level entrance exit

### DIFF
--- a/resources/world/world_data.gd
+++ b/resources/world/world_data.gd
@@ -402,7 +402,7 @@ func get_rooms_of_type(p_type: int) -> Array:
 func get_starting_room_data() -> RoomData:
 	var value: RoomData = null
 	
-	var starting_rooms := get_rooms_of_type(RoomData.OriginalPurpose.ENTRY_STAIRCASE)
+	var starting_rooms := get_rooms_of_type(RoomData.OriginalPurpose.UP_STAIRCASE)
 	if rooms.empty():
 		push_error("No starting room found.")
 		return value

--- a/resources/world/world_data.gd
+++ b/resources/world/world_data.gd
@@ -402,7 +402,7 @@ func get_rooms_of_type(p_type: int) -> Array:
 func get_starting_room_data() -> RoomData:
 	var value: RoomData = null
 	
-	var starting_rooms := get_rooms_of_type(RoomData.OriginalPurpose.LEVEL_STAIRCASE)
+	var starting_rooms := get_rooms_of_type(RoomData.OriginalPurpose.ENTRY_STAIRCASE)
 	if rooms.empty():
 		push_error("No starting room found.")
 		return value
@@ -738,7 +738,7 @@ func print_world_map() -> void:
 	print("\n" + title + append_title)
 	
 	var starting_room := get_starting_room_data()
-	var starting_cells := starting_room.cell_indexes.duplicate() if not starting_room == null else []
+	var starting_cells := starting_room.cell_indexes.duplicate() if starting_room != null else []
 	for y in range(0, world_size_z):
 		for x in range(0, world_size_x):
 			var index := get_cell_index_from_int_position(x, y)

--- a/scenes/worlds/procedural_world/generate_level_staircase.gd
+++ b/scenes/worlds/procedural_world/generate_level_staircase.gd
@@ -44,12 +44,12 @@ func _generate_rooms(data : WorldData, gen_data : Dictionary, generation_seed : 
 	var rooms: Array = gen_data[ROOM_ARRAY_KEY] if gen_data.has(ROOM_ARRAY_KEY) else Array()
 	
 	var entry_room := _gen_staircase_room_rect(data, random)
-	data.fill_room_data(entry_room, RoomData.OriginalPurpose.ENTRY_STAIRCASE)
+	data.fill_room_data(entry_room, RoomData.OriginalPurpose.UP_STAIRCASE)
 	data.player_spawn_position = entry_room.position + player_offset
 	rooms.append(entry_room)
 	
 	var exit_room := _gen_staircase_room_rect(data, random)
-	data.fill_room_data(exit_room, RoomData.OriginalPurpose.EXIT_STAIRCASE)
+	data.fill_room_data(exit_room, RoomData.OriginalPurpose.DOWN_STAIRCASE)
 	rooms.append(exit_room)
 	
 	gen_data[ROOM_ARRAY_KEY] = rooms

--- a/scenes/worlds/procedural_world/generate_level_staircase.gd
+++ b/scenes/worlds/procedural_world/generate_level_staircase.gd
@@ -35,7 +35,6 @@ export var player_offset := Vector2.ONE
 # under the key ROOM_ARRAY_KEY
 func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
 	_generate_rooms(data, gen_data, generation_seed)
-	_fill_map_data(data, gen_data)
 
 
 func _generate_rooms(data : WorldData, gen_data : Dictionary, generation_seed : int):
@@ -43,12 +42,20 @@ func _generate_rooms(data : WorldData, gen_data : Dictionary, generation_seed : 
 	random.seed = generation_seed
 	
 	var rooms: Array = gen_data[ROOM_ARRAY_KEY] if gen_data.has(ROOM_ARRAY_KEY) else Array()
-	rooms.append(_gen_starting_room_rect(data, random))
+	
+	var entry_room := _gen_staircase_room_rect(data, random)
+	data.fill_room_data(entry_room, RoomData.OriginalPurpose.ENTRY_STAIRCASE)
+	data.player_spawn_position = entry_room.position + player_offset
+	rooms.append(entry_room)
+	
+	var exit_room := _gen_staircase_room_rect(data, random)
+	data.fill_room_data(exit_room, RoomData.OriginalPurpose.EXIT_STAIRCASE)
+	rooms.append(exit_room)
 	
 	gen_data[ROOM_ARRAY_KEY] = rooms
 
 
-func _gen_starting_room_rect(data : WorldData, random : RandomNumberGenerator) -> Rect2:
+func _gen_staircase_room_rect(data : WorldData, random : RandomNumberGenerator) -> Rect2:
 	var value := Rect2()
 	
 	var p_x = random.randi_range(1, data.get_size_x() - 1 - single_tile_width)
@@ -57,13 +64,6 @@ func _gen_starting_room_rect(data : WorldData, random : RandomNumberGenerator) -
 	value = Rect2(p_x, p_z, single_tile_width, single_tile_height)
 	return value
 
-
-func _fill_map_data(data : WorldData, gen_data : Dictionary):
-	var rooms : Array = gen_data.get(ROOM_ARRAY_KEY) as Array
-	
-	var starting_room := rooms[0] as Rect2
-	data.fill_room_data(starting_room, RoomData.OriginalPurpose.LEVEL_STAIRCASE)
-	data.player_spawn_position = starting_room.position + player_offset
 
 ### -----------------------------------------------------------------------------------------------
 

--- a/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
@@ -225,8 +225,7 @@ func _generate_corridor_until_first_door(data: WorldData, astar: AStar2D, a: int
 				has_reached_b = CorridorGenerationResults.DOOR
 				break
 		
-		if not astar_type == AstarType.ROOM:
-			astar.set_point_weight_scale(cells[2], existing_corridor_weight)
+		astar.set_point_weight_scale(cells[2], existing_corridor_weight)
 	
 	return has_reached_b
 

--- a/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_corridors.gd
@@ -1,14 +1,52 @@
 extends GenerationStep
 
+### Member Variables and Dependencies -------------------------------------------------------------
+#--- signals --------------------------------------------------------------------------------------
+
+#--- enums ----------------------------------------------------------------------------------------
+
+enum AstarType {
+	EMPTY,
+	ROOM,
+	EDGE,
+}
+
+enum CorridorGenerationResults {
+	FAILED,
+	DOOR,
+	GOAL,
+}
+
+#--- constants ------------------------------------------------------------------------------------
+
 const GraphGenerator = preload("generate_room_graph.gd")
+
+const MASK_EMPTY = 0b0000
+const MASK_ROOM_TOP_LEFT = 0b0001
+const MASK_ROOM_TOP_RIGHT = 0b0010
+const MASK_ROOM_BOTTOM_RIGHT = 0b0100
+const MASK_ROOM_BOTTOM_LEFT = 0b1000
+
+const MASK_ROOM_NORTH = MASK_ROOM_TOP_LEFT | MASK_ROOM_TOP_RIGHT
+const MASK_ROOM_EAST = MASK_ROOM_TOP_RIGHT | MASK_ROOM_BOTTOM_RIGHT
+const MASK_ROOM_SOUTH = MASK_ROOM_BOTTOM_LEFT | MASK_ROOM_BOTTOM_RIGHT
+const MASK_ROOM_WEST = MASK_ROOM_TOP_LEFT | MASK_ROOM_BOTTOM_LEFT
+const MASK_FULL_ROOM = 0b1111
+
+#--- public variables - order: export > normal var > onready --------------------------------------
 
 export var existing_corridor_weight : float = 0.5
 export var existing_room_weight : float = 2.0
 export var room_edge_cost_multiplier : float = 1.5
 
+#--- private variables - order: export > normal var > onready -------------------------------------
 
-# Override this function
-func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
+### -----------------------------------------------------------------------------------------------
+
+
+### GenerationStep Virtual Overrides --------------------------------------------------------------------
+
+func _execute_step(data : WorldData, gen_data : Dictionary, _generation_seed : int):
 	var graph = gen_data.get(GraphGenerator.CONNECTION_GRAPH_KEY, Dictionary()) as Dictionary
 	var astar = generate_double_a_star_grid(data)
 	for a in graph.keys():
@@ -16,102 +54,28 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 			generate_double_corridor(data, astar, a, b)
 	pass
 
+### -----------------------------------------------------------------------------------------------
 
-func get_cell_mask(data : WorldData, cells : Array, value: int) -> int:
-	var mask = 0b0000
-	mask = mask | 0b0001*int(data.get_cell_type(cells[0]) == value)
-	mask = mask | 0b0010*int(data.get_cell_type(cells[1]) == value)
-	mask = mask | 0b0100*int(data.get_cell_type(cells[2]) == value)
-	mask = mask | 0b1000*int(data.get_cell_type(cells[3]) == value)
-	return mask
 
+### Public Methods --------------------------------------------------------------------------------
 
 func generate_double_a_star_grid(data : WorldData) -> AStar2D:
 	var astar = ManhattanAStar2D.new()
-	for x in range(2, data.world_size_x - 1):
-		for z in range(2, data.world_size_z - 1):
-			var cells = [
-				data.get_cell_index_from_int_position(x - 1, z - 1),
-				data.get_cell_index_from_int_position(x, z - 1),
-				data.get_cell_index_from_int_position(x, z),
-				data.get_cell_index_from_int_position(x - 1, z),
-			]
-			var room_mask = get_cell_mask(data, cells, data.CellType.ROOM)
-			var p : Vector2 = Vector2(x, z)
-			
-			var w = 1.0
-			# fully outside of a room
-			if room_mask == 0b0000:
-				w = 1.0
-			# fully inside of a room
-			elif room_mask == 0b1111:
-				w = existing_room_weight
-			# at the edge of a room
-			elif room_mask == 0b0011 or room_mask == 0b0110 or room_mask == 0b1100 or room_mask == 0b1001:
-				# high weight to make crossing the edge mostly perpendicular
-				w = room_edge_cost_multiplier*existing_room_weight
-			# at the corner of one or more rooms (internal or external)
-			else:
-				# don't add corner points
-				continue
-			astar.add_point(cells[2], p, w)
-	for x in range(1, data.world_size_x-1):
-		for z in range(1, data.world_size_z-1):
-			var i = data.get_cell_index_from_int_position(x, z)
-			if not astar.has_point(i):
-				continue
-			if x != data.world_size_x - 1:
-				var e = data.get_neighbour_cell(i, data.Direction.EAST)
-				if astar.has_point(e):
-					astar.connect_points(i, e)
-			if x != 1:
-				var w = data.get_neighbour_cell(i, data.Direction.WEST)
-				if astar.has_point(w):
-					astar.connect_points(i, w)
-			if z != data.world_size_z - 1:
-				var s = data.get_neighbour_cell(i, data.Direction.SOUTH)
-				if astar.has_point(s):
-					astar.connect_points(i, s)
-			if z != 1:
-				var n = data.get_neighbour_cell(i, data.Direction.NORTH)
-				if astar.has_point(n):
-					astar.connect_points(i, n)
+	_add_weighted_points_to_astar_grid(data, astar)
+	_connect_points_in_astar_grid(data, astar)
 	return astar
-
-
-func set_cells(data : WorldData, cells : Array, values : Array):
-	for i in cells.size():
-		if values [i] > data.get_cell_type(cells[i]):
-			data.set_cell_type(cells[i], values[i])
-
-
-func add_door_direction(data : WorldData, cell : int, value : int):
-	if not data.has_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS):
-		data.set_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS, Array())
-	if not data.get_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS).has(value):
-		data.get_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS).push_back(value)
-
-
-func set_doorways_meta(data: WorldData, cells: Array, direction: int) -> void:
-	if cells.empty():
-		return
-	
-	for cell in cells:
-		if data.get_cell_type(cell) == data.CellType.ROOM:
-			var room_data := data.get_cell_meta(cell, data.CellMetaKeys.META_ROOM_DATA) as RoomData
-			room_data.set_doorway_cell(cell, data.direction_inverse(direction))
-		elif data.get_cell_type(cell) == data.CellType.DOOR:
-			add_door_direction(data, cell, direction)
 
 
 func generate_double_corridor(data : WorldData, astar : AStar2D, a : int, b : int) -> bool:
 	var path : PoolIntArray = astar.get_id_path(a, b)
 	if not (path.size() > 0 and path[0] == a and path[-1] == b):
-		print(a)
-		print(data.get_int_position_from_cell_index(a))
-		print(b)
-		print(data.get_int_position_from_cell_index(b))
+		print("a: %s (%s) | b: %s (%s) | path[0]: %s | path[-1]: %s"%[
+				a, data.get_int_position_from_cell_index(a), 
+				b, data.get_int_position_from_cell_index(b),
+				path[0], path[-1]
+		])
 		return false
+	
 	for i in path.size():
 		var coords = data.get_int_position_from_cell_index(path[i])
 		var x = coords[0]
@@ -121,49 +85,51 @@ func generate_double_corridor(data : WorldData, astar : AStar2D, a : int, b : in
 				data.get_cell_index_from_int_position(x, z - 1),
 				data.get_cell_index_from_int_position(x, z),
 				data.get_cell_index_from_int_position(x - 1, z),
-			]
+		]
 		# room mask as 3210 (clockwise order from lower bit)
-		var rooms = get_cell_mask(data, cells, data.CellType.ROOM)
+		var mask_2x2 = _get_cell_mask(data, cells, data.CellType.ROOM)
 		
-		var is_edge = false   # Yellow warning in editor; var never used
-		var is_room = false
-		match rooms:
-			0b0000:
-				set_cells(data, cells, [
+		var astar_type := AstarType.EMPTY as int
+		match mask_2x2:
+			MASK_EMPTY:
+				_set_cells(data, cells, [
 						data.CellType.CORRIDOR, data.CellType.CORRIDOR, 
 						data.CellType.CORRIDOR, data.CellType.CORRIDOR
 				])
-			0b0011:
-				set_cells(data, cells, [
+			MASK_ROOM_NORTH:
+				_set_cells(data, cells, [
 						data.CellType.ROOM, data.CellType.ROOM, 
 						data.CellType.DOOR, data.CellType.DOOR
 				])
-				set_doorways_meta(data, cells, data.Direction.NORTH)
-				is_edge = true
-			0b0110:
-				set_cells(data, cells, [
+				_set_doorways_meta(data, cells, data.Direction.NORTH)
+				astar_type = AstarType.EDGE
+			MASK_ROOM_EAST:
+				_set_cells(data, cells, [
 						data.CellType.DOOR, data.CellType.ROOM, 
 						data.CellType.ROOM, data.CellType.DOOR
 				])
-				set_doorways_meta(data, cells, data.Direction.EAST)
-				is_edge = true
-			0b1100:
-				set_cells(data, cells, [
+				_set_doorways_meta(data, cells, data.Direction.EAST)
+				astar_type = AstarType.EDGE
+			MASK_ROOM_SOUTH:
+				_set_cells(data, cells, [
 						data.CellType.DOOR, data.CellType.DOOR, 
 						data.CellType.ROOM, data.CellType.ROOM
 				])
-				set_doorways_meta(data, cells, data.Direction.SOUTH)
-				is_edge = true
-			0b1001:
-				set_cells(data, cells, [
+				_set_doorways_meta(data, cells, data.Direction.SOUTH)
+				astar_type = AstarType.EDGE
+			MASK_ROOM_WEST:
+				_set_cells(data, cells, [
 						data.CellType.ROOM, data.CellType.DOOR, 
 						data.CellType.DOOR, data.CellType.ROOM]
 				)
-				set_doorways_meta(data, cells, data.Direction.WEST)
-				is_edge = true
-			0b1111:
-				is_room = true
-		if not is_room:
+				_set_doorways_meta(data, cells, data.Direction.WEST)
+				astar_type = AstarType.EDGE
+			MASK_FULL_ROOM:
+				astar_type = AstarType.ROOM
+		
+		if astar_type == AstarType.EDGE:
+			astar.set_point_weight_scale(cells[2], existing_corridor_weight * room_edge_cost_multiplier)
+		elif astar_type == AstarType.EMPTY:
 			astar.set_point_weight_scale(cells[2], existing_corridor_weight)
 	
 	var rooms := [
@@ -174,15 +140,120 @@ func generate_double_corridor(data : WorldData, astar : AStar2D, a : int, b : in
 	for room_value in rooms:
 		var room := room_value as RoomData
 		if not room.can_add_doorway():
-			var doorway_cells := room.get_all_doorway_cells()
-			for cell_index in room.cell_indexes:
-				for direction in data.Direction.values():
-					if direction == data.Direction.DIRECTION_MAX or cell_index in doorway_cells:
-						continue
-					
-					var neighbour_index := data.get_neighbour_cell(cell_index, direction)
-					if not neighbour_index in room.cell_indexes:
-						if astar.are_points_connected(cell_index, neighbour_index):
-							astar.disconnect_points(cell_index, neighbour_index)
+			_disconnect_room_walls_from_grid(data, astar, room)
 	
 	return true
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Private Methods -------------------------------------------------------------------------------
+
+func _add_weighted_points_to_astar_grid(data: WorldData, astar: AStar2D) -> void:
+	for x in range(1, data.world_size_x - 1):
+		for z in range(1, data.world_size_z - 1):
+			var cells = [
+				data.get_cell_index_from_int_position(x - 1, z - 1),
+				data.get_cell_index_from_int_position(x, z - 1),
+				data.get_cell_index_from_int_position(x, z),
+				data.get_cell_index_from_int_position(x - 1, z),
+			]
+			
+			var room_mask = _get_cell_mask(data, cells, data.CellType.ROOM)
+			var point := Vector2(x, z)
+			var weight := _get_weight_for(room_mask)
+			if weight > 0:
+				astar.add_point(cells[2], point, weight)
+
+
+func _get_cell_mask(data : WorldData, cells : Array, value: int) -> int:
+	var mask = MASK_EMPTY
+	mask = mask | MASK_ROOM_TOP_LEFT * int(data.get_cell_type(cells[0]) == value)
+	mask = mask | MASK_ROOM_TOP_RIGHT * int(data.get_cell_type(cells[1]) == value)
+	mask = mask | MASK_ROOM_BOTTOM_RIGHT * int(data.get_cell_type(cells[2]) == value)
+	mask = mask | MASK_ROOM_BOTTOM_LEFT * int(data.get_cell_type(cells[3]) == value)
+	return mask
+
+
+func _get_weight_for(room_mask: int) -> float:
+	var weight = 1.0
+	
+	# fully outside of a room
+	if room_mask == MASK_EMPTY:
+		weight = 1.0
+	# fully inside of a room
+	elif room_mask == MASK_FULL_ROOM:
+		weight = existing_room_weight
+	# at the edge of a room
+	elif (
+			room_mask == MASK_ROOM_NORTH 
+			or room_mask == MASK_ROOM_EAST 
+			or room_mask == MASK_ROOM_SOUTH 
+			or room_mask == MASK_ROOM_WEST
+	):
+		# high weight to make crossing the edge mostly perpendicular
+		weight = room_edge_cost_multiplier * existing_room_weight
+	# at the corner of one or more rooms (internal or external)
+	else:
+		weight = 0
+	
+	return weight
+
+
+func _connect_points_in_astar_grid(data: WorldData, astar: AStar2D) -> void:
+	for x in range(1, data.world_size_x-1):
+		for z in range(1, data.world_size_z-1):
+			var cell_index = data.get_cell_index_from_int_position(x, z)
+			if not astar.has_point(cell_index):
+				continue
+			
+			for direction in data.Direction.DIRECTION_MAX:
+				var neighbour = data.get_neighbour_cell(cell_index, direction)
+				if neighbour != -1 and astar.has_point(neighbour):
+					astar.connect_points(cell_index, neighbour)
+
+
+func _set_cells(data : WorldData, cells : Array, values : Array):
+	for i in cells.size():
+		if values [i] > data.get_cell_type(cells[i]):
+			data.set_cell_type(cells[i], values[i])
+
+
+func _add_door_direction(data : WorldData, cell : int, value : int):
+	if not data.has_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS):
+		data.set_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS, Array())
+	if not data.get_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS).has(value):
+		data.get_cell_meta(cell, data.CellMetaKeys.META_DOOR_DIRECTIONS).push_back(value)
+
+
+func _set_doorways_meta(data: WorldData, cells: Array, direction: int) -> void:
+	if cells.empty():
+		return 
+	
+	for cell in cells:
+		if data.get_cell_type(cell) == data.CellType.ROOM:
+			var room_data := data.get_cell_meta(cell, data.CellMetaKeys.META_ROOM_DATA) as RoomData
+			var corridor_direction = data.direction_inverse(direction)
+			room_data.set_doorway_cell(cell, corridor_direction)
+		elif data.get_cell_type(cell) == data.CellType.DOOR:
+			_add_door_direction(data, cell, direction)
+
+
+func _disconnect_room_walls_from_grid(data: WorldData, astar: AStar2D, room: RoomData) -> void:
+	var doorway_cells := room.get_all_doorway_cells()
+	for cell_index in room.cell_indexes:
+		for direction in data.Direction.DIRECTION_MAX:
+			if cell_index in doorway_cells:
+				continue
+			
+			var neighbour_index := data.get_neighbour_cell(cell_index, direction)
+			if neighbour_index != -1 and not neighbour_index in room.cell_indexes:
+				if astar.are_points_connected(cell_index, neighbour_index):
+					astar.disconnect_points(cell_index, neighbour_index)
+
+### -----------------------------------------------------------------------------------------------
+
+
+### Signal Callbacks ------------------------------------------------------------------------------
+
+### -----------------------------------------------------------------------------------------------

--- a/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
@@ -10,16 +10,6 @@ export var edges_to_keep_abs_min : int = 2
 
 const RoomGenerator = preload("generate_rooms.gd")
 
-# Array of indices that represent "entry" or "up" staircases. These can only connect TO other rooms
-# but not be connected FROM other rooms, because Mooses2k wants level staircases to only have one
-# door.
-var _entry_staircases := []
-
-# Array of indices that represent "exit" or "down" staircases. These can only be connected FROM 
-# other rooms but connect TO other rooms, because Mooses2k wants level staircases to only have one
-# door.
-var _exit_staircases := []
-
 
 # Generates a graph connecting rooms to each other, the graph is generated
 # as a Dictionary, where the key K represents the cell of index K, and the value
@@ -34,7 +24,6 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 		var groups : Array = group_intersecting_rooms(rooms)
 		var delaunay : Dictionary = get_delaunay_from_groupings(data, groups, random)
 		gen_data[DELAUNAY_GRAPH_KEY] = delaunay.duplicate(true)
-		_exclude_unwanted_edges(delaunay, random)
 		var graph : Dictionary = get_mst_from_delaunay(data, delaunay)
 		add_extra_edges(delaunay, graph, random)
 		gen_data[CONNECTION_GRAPH_KEY] = graph
@@ -110,16 +99,8 @@ func get_delaunay_from_groupings(data : WorldData, groups : Array, random : Rand
 		var room = groups[i][r] as Rect2
 		var center = room.position + 0.5*room.size
 		var x = int(center.x)
-		var y = int(center.y)	
-		
-		var cell_index := data.get_cell_index_from_int_position(x, y)
-		var room_data := data.get_cell_meta(cell_index, data.CellMetaKeys.META_ROOM_DATA) as RoomData
-		if room_data.type == room_data.OriginalPurpose.UP_STAIRCASE:
-			_entry_staircases.append(cell_index)
-		elif room_data.type == room_data.OriginalPurpose.DOWN_STAIRCASE:
-			_exit_staircases.append(cell_index)
-		
-		cells[i] = cell_index
+		var y = int(center.y)
+		cells[i] = data.get_cell_index_from_int_position(x, y)
 		room_centers[i] = center
 	var delaunay : PoolIntArray = Geometry.triangulate_delaunay_2d(room_centers)
 	for i in delaunay.size()/3:
@@ -216,73 +197,3 @@ func graph_get_edges(graph : Dictionary, from : int) -> Array:
 			result.push_back(i)
 	result.append_array(graph.get(from, []))
 	return result
-
-
-func _exclude_unwanted_edges(delaunay: Dictionary, random: RandomNumberGenerator) -> void:
-	_exclude_incoming_connections_from_entry_staircases(delaunay, random)
-	_exclude_outgoing_connections_from_exit_staircases(delaunay, random)
-
-
-# Excludes all incoming connetions to enter staircaises, and if entry staircases have more than
-# one outgoing connections, exclude them randomly until there is only one.
-func _exclude_incoming_connections_from_entry_staircases(
-		delaunay: Dictionary, random: RandomNumberGenerator
-) -> void:
-	var exclude_possibilities := []
-	for staircase_index in _entry_staircases:
-		for cell_index in delaunay:
-			var edges := delaunay[cell_index] as Array
-			if cell_index != staircase_index:
-				var index_to_exclude := edges.find(staircase_index)
-				if index_to_exclude != -1:
-					var exclude_data := {
-						cell_index = cell_index,
-						edge_index = index_to_exclude
-					}
-					exclude_possibilities.append(exclude_data)
-			else:
-				if edges.size() > 1:
-					var original_size := edges.size()
-					for _i in original_size - 1:
-						var random_index := random.randi() % edges.size()
-						edges.remove(random_index)
-	
-	if exclude_possibilities.size() > 1:
-		_exclude_connection_randomly_until(1, exclude_possibilities, delaunay, random)
-
-
-# Excludes all outgoing connection from exit staircases, and makes a list of incoming connections,
-# if there are more than one incoming connection, randomly delete them until there is only one.
-func _exclude_outgoing_connections_from_exit_staircases(
-		delaunay: Dictionary, random: RandomNumberGenerator
-) -> void:
-	var exclude_possibilities := []
-	for staircase_index in _exit_staircases:
-		var keys := delaunay.keys()
-		for cell_index in keys:
-			var edges := delaunay[cell_index] as Array
-			if cell_index != staircase_index:
-				var index_to_exclude := edges.find(staircase_index)
-				if index_to_exclude != -1:
-					var exclude_data := {
-						cell_index = cell_index,
-						edge_index = index_to_exclude
-					}
-					exclude_possibilities.append(exclude_data)
-			else:
-				if edges.size() > 0:
-					delaunay.erase(cell_index)
-	
-	if exclude_possibilities.size() > 1:
-		_exclude_connection_randomly_until(1, exclude_possibilities, delaunay, random)
-
-
-func _exclude_connection_randomly_until(
-		size_left: int, to_exclude: Array, delaunay: Dictionary,  random: RandomNumberGenerator
-) -> void:
-	var iterations_to_exclude := to_exclude.size() - size_left
-	for _i in iterations_to_exclude:
-		var random_index := random.randi() % to_exclude.size()
-		var exclude_data := to_exclude[random_index] as Dictionary
-		delaunay[exclude_data.cell_index].remove(exclude_data.edge_index)
-		to_exclude.remove(random_index)

--- a/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
@@ -114,9 +114,9 @@ func get_delaunay_from_groupings(data : WorldData, groups : Array, random : Rand
 		
 		var cell_index := data.get_cell_index_from_int_position(x, y)
 		var room_data := data.get_cell_meta(cell_index, data.CellMetaKeys.META_ROOM_DATA) as RoomData
-		if room_data.type == room_data.OriginalPurpose.ENTRY_STAIRCASE:
+		if room_data.type == room_data.OriginalPurpose.UP_STAIRCASE:
 			_entry_staircases.append(cell_index)
-		elif room_data.type == room_data.OriginalPurpose.EXIT_STAIRCASE:
+		elif room_data.type == room_data.OriginalPurpose.DOWN_STAIRCASE:
 			_exit_staircases.append(cell_index)
 		
 		cells[i] = cell_index

--- a/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_room_graph.gd
@@ -10,6 +10,16 @@ export var edges_to_keep_abs_min : int = 2
 
 const RoomGenerator = preload("generate_rooms.gd")
 
+# Array of indices that represent "entry" or "up" staircases. These can only connect TO other rooms
+# but not be connected FROM other rooms, because Mooses2k wants level staircases to only have one
+# door.
+var _entry_staircases := []
+
+# Array of indices that represent "exit" or "down" staircases. These can only be connected FROM 
+# other rooms but connect TO other rooms, because Mooses2k wants level staircases to only have one
+# door.
+var _exit_staircases := []
+
 
 # Generates a graph connecting rooms to each other, the graph is generated
 # as a Dictionary, where the key K represents the cell of index K, and the value
@@ -24,6 +34,7 @@ func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : in
 		var groups : Array = group_intersecting_rooms(rooms)
 		var delaunay : Dictionary = get_delaunay_from_groupings(data, groups, random)
 		gen_data[DELAUNAY_GRAPH_KEY] = delaunay.duplicate(true)
+		_exclude_unwanted_edges(delaunay, random)
 		var graph : Dictionary = get_mst_from_delaunay(data, delaunay)
 		add_extra_edges(delaunay, graph, random)
 		gen_data[CONNECTION_GRAPH_KEY] = graph
@@ -99,8 +110,16 @@ func get_delaunay_from_groupings(data : WorldData, groups : Array, random : Rand
 		var room = groups[i][r] as Rect2
 		var center = room.position + 0.5*room.size
 		var x = int(center.x)
-		var y = int(center.y)
-		cells[i] = data.get_cell_index_from_int_position(x, y)
+		var y = int(center.y)	
+		
+		var cell_index := data.get_cell_index_from_int_position(x, y)
+		var room_data := data.get_cell_meta(cell_index, data.CellMetaKeys.META_ROOM_DATA) as RoomData
+		if room_data.type == room_data.OriginalPurpose.ENTRY_STAIRCASE:
+			_entry_staircases.append(cell_index)
+		elif room_data.type == room_data.OriginalPurpose.EXIT_STAIRCASE:
+			_exit_staircases.append(cell_index)
+		
+		cells[i] = cell_index
 		room_centers[i] = center
 	var delaunay : PoolIntArray = Geometry.triangulate_delaunay_2d(room_centers)
 	for i in delaunay.size()/3:
@@ -197,3 +216,73 @@ func graph_get_edges(graph : Dictionary, from : int) -> Array:
 			result.push_back(i)
 	result.append_array(graph.get(from, []))
 	return result
+
+
+func _exclude_unwanted_edges(delaunay: Dictionary, random: RandomNumberGenerator) -> void:
+	_exclude_incoming_connections_from_entry_staircases(delaunay, random)
+	_exclude_outgoing_connections_from_exit_staircases(delaunay, random)
+
+
+# Excludes all incoming connetions to enter staircaises, and if entry staircases have more than
+# one outgoing connections, exclude them randomly until there is only one.
+func _exclude_incoming_connections_from_entry_staircases(
+		delaunay: Dictionary, random: RandomNumberGenerator
+) -> void:
+	var exclude_possibilities := []
+	for staircase_index in _entry_staircases:
+		for cell_index in delaunay:
+			var edges := delaunay[cell_index] as Array
+			if cell_index != staircase_index:
+				var index_to_exclude := edges.find(staircase_index)
+				if index_to_exclude != -1:
+					var exclude_data := {
+						cell_index = cell_index,
+						edge_index = index_to_exclude
+					}
+					exclude_possibilities.append(exclude_data)
+			else:
+				if edges.size() > 1:
+					var original_size := edges.size()
+					for _i in original_size - 1:
+						var random_index := random.randi() % edges.size()
+						edges.remove(random_index)
+	
+	if exclude_possibilities.size() > 1:
+		_exclude_connection_randomly_until(1, exclude_possibilities, delaunay, random)
+
+
+# Excludes all outgoing connection from exit staircases, and makes a list of incoming connections,
+# if there are more than one incoming connection, randomly delete them until there is only one.
+func _exclude_outgoing_connections_from_exit_staircases(
+		delaunay: Dictionary, random: RandomNumberGenerator
+) -> void:
+	var exclude_possibilities := []
+	for staircase_index in _exit_staircases:
+		var keys := delaunay.keys()
+		for cell_index in keys:
+			var edges := delaunay[cell_index] as Array
+			if cell_index != staircase_index:
+				var index_to_exclude := edges.find(staircase_index)
+				if index_to_exclude != -1:
+					var exclude_data := {
+						cell_index = cell_index,
+						edge_index = index_to_exclude
+					}
+					exclude_possibilities.append(exclude_data)
+			else:
+				if edges.size() > 0:
+					delaunay.erase(cell_index)
+	
+	if exclude_possibilities.size() > 1:
+		_exclude_connection_randomly_until(1, exclude_possibilities, delaunay, random)
+
+
+func _exclude_connection_randomly_until(
+		size_left: int, to_exclude: Array, delaunay: Dictionary,  random: RandomNumberGenerator
+) -> void:
+	var iterations_to_exclude := to_exclude.size() - size_left
+	for _i in iterations_to_exclude:
+		var random_index := random.randi() % to_exclude.size()
+		var exclude_data := to_exclude[random_index] as Dictionary
+		delaunay[exclude_data.cell_index].remove(exclude_data.edge_index)
+		to_exclude.remove(random_index)

--- a/scenes/worlds/world_gen/generation_steps/generate_rooms.gd
+++ b/scenes/worlds/world_gen/generation_steps/generate_rooms.gd
@@ -14,6 +14,8 @@ export var min_intersection_size : int = 3
 
 export(Array, WorldData.CellType) var override_cells : Array = [WorldData.CellType.EMPTY]
 
+var _initial_rooms_size := 0
+
 var actual_room_max : int
 var actual_room_min : int
 
@@ -21,6 +23,8 @@ var actual_room_min : int
 # Randomly generates a set of rooms into data, stores the generated rooms
 # as an array of Rect2 into gen_data, under the ket ROOM_ARRAY_KEY
 func _execute_step(data : WorldData, gen_data : Dictionary, generation_seed : int):
+	if gen_data.has(ROOM_ARRAY_KEY):
+		_initial_rooms_size = gen_data[ROOM_ARRAY_KEY].size()
 	generate_rooms(data, gen_data, generation_seed)
 	fill_map_data(data, gen_data)
 
@@ -69,7 +73,7 @@ func check_room_space(data : WorldData, room : Rect2) -> bool:
 func fill_map_data(data : WorldData, gen_data : Dictionary):
 	var rooms : Array = gen_data.get(ROOM_ARRAY_KEY) as Array
 	
-	for index in range(1, rooms.size()):
+	for index in range(_initial_rooms_size, rooms.size()):
 		var room : Rect2 = rooms[index] as Rect2
 		data.fill_room_data(room, RoomData.OriginalPurpose.EMPTY)
 

--- a/scenes/worlds/world_gen/helper_objects/room_data.gd
+++ b/scenes/worlds/world_gen/helper_objects/room_data.gd
@@ -80,8 +80,27 @@ func set_doorway_cell(cell_index: int, direction: int) -> void:
 		push_warning("this doorway has already been registered.")
 
 
+func can_add_doorway() -> bool:
+	var value = true
+	
+	if (
+			(type == OriginalPurpose.UP_STAIRCASE or type == OriginalPurpose.DOWN_STAIRCASE) 
+			and _doorways.size() > 0
+	):
+		value = false
+	
+	return value
+
+
 func get_doorway_directions() -> Array:
 	return _doorways.keys()
+
+
+func get_all_doorway_cells() -> Array:
+	var all_doorways = []
+	for direction in _doorways:
+		all_doorways.append_array(_doorways[direction])
+	return all_doorways
 
 
 # Returns an Array with cell indexes for doorways in the asked direction. If there is none, 

--- a/scenes/worlds/world_gen/helper_objects/room_data.gd
+++ b/scenes/worlds/world_gen/helper_objects/room_data.gd
@@ -11,8 +11,8 @@ enum OriginalPurpose {
 	EMPTY,
 	CRYPT,
 	FOUNTAIN,
-	ENTRY_STAIRCASE,
-	EXIT_STAIRCASE
+	UP_STAIRCASE,
+	DOWN_STAIRCASE
 }
 
 #--- constants ------------------------------------------------------------------------------------

--- a/scenes/worlds/world_gen/helper_objects/room_data.gd
+++ b/scenes/worlds/world_gen/helper_objects/room_data.gd
@@ -11,7 +11,8 @@ enum OriginalPurpose {
 	EMPTY,
 	CRYPT,
 	FOUNTAIN,
-	LEVEL_STAIRCASE,
+	ENTRY_STAIRCASE,
+	EXIT_STAIRCASE
 }
 
 #--- constants ------------------------------------------------------------------------------------
@@ -52,7 +53,7 @@ func _init(p_type := OriginalPurpose.EMPTY, p_rect2 := Rect2()) -> void:
 
 func _to_string() -> String:
 	var msg := "\n---- RoomData %s \n"%[get_instance_id()]
-	msg += "type: %s | rect2: %s | has_pillars: %s\n"%[type, rect2, has_pillars]
+	msg += "type: %s | rect2: %s | has_pillars: %s\n"%[OriginalPurpose.keys()[type], rect2, has_pillars]
 	msg += "cell_indexes: %s \n"%[cell_indexes]
 	msg += "---- RoomData End %s \n"%[get_instance_id()]
 	return msg

--- a/utils/debug_scenes/limit_doorways_debug.tscn
+++ b/utils/debug_scenes/limit_doorways_debug.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=10 format=2]
+
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_room_graph.gd" type="Script" id=1]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_rooms.gd" type="Script" id=2]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_room_pillars.gd" type="Script" id=3]
+[ext_resource path="res://scenes/worlds/procedural_world/generate_level_staircase.gd" type="Script" id=4]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_walls.gd" type="Script" id=5]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_halls.gd" type="Script" id=6]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_corridors.gd" type="Script" id=7]
+[ext_resource path="res://scenes/worlds/world_gen/generation_steps/generate_grid_tiles.gd" type="Script" id=8]
+[ext_resource path="res://utils/debug_scenes/_base/base_standalone_game_world.tscn" type="PackedScene" id=9]
+
+[node name="DebugWorld" instance=ExtResource( 9 )]
+
+[node name="GenerationManager" parent="." index="5"]
+world_size_x = 20
+world_size_z = 20
+generation_seed = 3
+
+[node name="GenerateLevelStaircase" type="Node" parent="GenerationManager" index="0"]
+script = ExtResource( 4 )
+
+[node name="GenerateRooms" type="Node" parent="GenerationManager" index="1"]
+script = ExtResource( 2 )
+room_size_min = 2
+room_size_max = 3
+
+[node name="GenerateRoomGraph" type="Node" parent="GenerationManager" index="2"]
+script = ExtResource( 1 )
+
+[node name="GenerateCorridors" type="Node" parent="GenerationManager" index="3"]
+script = ExtResource( 7 )
+
+[node name="GenerateHalls" type="Node" parent="GenerationManager" index="4"]
+script = ExtResource( 6 )
+
+[node name="GenerateWalls" type="Node" parent="GenerationManager" index="5"]
+script = ExtResource( 5 )
+
+[node name="GenerateRoomPillars" type="Node" parent="GenerationManager" index="6"]
+script = ExtResource( 3 )
+pillar_tile = 16
+
+[node name="GenerateGridTiles" type="Node" parent="GenerationManager" index="7"]
+script = ExtResource( 8 )
+floor_tile = 6
+wall_tile = 5
+door_tile = 19
+double_door_tile = 14
+ceiling_tile = 10
+pillar_room_double_wall_tile = 3
+pillar_room_double_door_tile = 1
+pillar_room_double_ceiling_tile = 18
+pillar_room_double_floor_tile = 7
+pillar_room_pillar_tile = 15
+pillar_tile = 16

--- a/utils/debug_scenes/limit_doorways_debug.tscn
+++ b/utils/debug_scenes/limit_doorways_debug.tscn
@@ -15,7 +15,6 @@
 [node name="GenerationManager" parent="." index="5"]
 world_size_x = 20
 world_size_z = 20
-generation_seed = 3
 
 [node name="GenerateLevelStaircase" type="Node" parent="GenerationManager" index="0"]
 script = ExtResource( 4 )


### PR DESCRIPTION
This PR is to make sure staircase rooms are limited to one door only.

The first approach was to make sure staircase rooms have only one connection in the graph phase of world generation. This was discarded because it didn't guarantee 100% that the rooms would have only one door but brought back later because it guarantees the dungeon will have loops that don't use the staircase rooms and thus have no risk of being discarded by corridor generation phase.

Then on corridor generation phase, there was a lot of refactors: 
- to make it more readable.
- to sever connections from the staircase room to the rest of the grid except through the first door that is created on it
- to break corridor generation every time a door is generated, so the path can be recalculated
  - both of the above fix the possibility of opening two doors in a staircase room because the path finding finds it cheaper to go through them to connect two other rooms