### PR TITLE
Fix character audio footstep sounds in built executable and loadScreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,10 @@ data_*/
 *.DS_Store
 *Thumbs.db
 *.directory
-
+Build/
 # Note - open issue, we want to avoid merging .blend and .spp etc large files into main...how?
+*.zip
+*.exe
+*.pck
+*.import
+

--- a/globals/load_scene.gd
+++ b/globals/load_scene.gd
@@ -1,59 +1,29 @@
 extends Node
 
-
-# warning-ignore:unused_signal
-signal scene_loaded
+const Loadscreen = preload("res://scenes/ui/loadscreen/load_screen.tscn")
+var next_scene : String 
+var target_node : Node = null
+var loading : bool = false
+#ONLY used for debug menu
 signal loading_screen_removed
 
-const Loadscreen = preload("res://scenes/ui/loadscreen/load_screen.tscn")
-var loadscreen : Node
+##To be used when changing to a different scene (menu to game, game to menu, game to credits, etc)
+func change_scene_to_file(path : String) -> void:
+	next_scene = path
+	loading = true
+	get_tree().change_scene_to_packed(Loadscreen)
 
+## To be used when loading an actual level to add to a node
+func load_level(path :String, target : Node, load_screen : LoadScreen):
+	target_node = target
+	next_scene = path
+	load_screen.start_loading()
 
-func setup_loadscreen() -> void:
-	loadscreen = Loadscreen.instantiate()
-	get_tree().current_scene.add_child(loadscreen)
+##To be used at the end of loading
+func clear_data():
+	next_scene = ""
+	target_node = null
 	
-	# Is here to hopefully ensure the quotes showup before the freeze on loading
-	await get_tree().create_timer(0.1).timeout   # To attempt to ensure lowend computers get something showing before it freezes
-	
-	get_tree().paused = true
-
-
-func remove_loadscreen() -> void:
-	get_tree().paused = false
-	
-	# Quiets out drop sounds on level load
-	AudioSettings.internal_effects_volume = 0.0
-	# warning-ignore:return_value_discarded
-	get_tree().create_tween()\
-		.tween_property(AudioSettings, "internal_effects_volume", 1.0, 5.0)\
-		.set_trans(Tween.TRANS_EXPO)\
-		.set_ease(Tween.EASE_IN)
-	
-	# Fade-in
-	loadscreen.label.visible = false
-	loadscreen.quote.visible = false
-	get_tree().create_tween()\
-		.tween_property(loadscreen.color_rect, "color", Color(0, 0, 0, 0), 3.0)\
-		.set_ease(Tween.EASE_IN)
-	
-	# Disable LeftClick for a moment so player doesn't accidentally shoot or something immediately
-	GameManager.game.player.player_controller.no_click_after_load_period = true
-	await get_tree().create_timer(1).timeout   # Possibly 0.5 better?
-	GameManager.game.player.player_controller.no_click_after_load_period = false
-	loadscreen.visible = false
-	
-	# Wait another moment then kill the loadscreen
-	# Be aware, during this time period drop_sound doesn't play to avoid stuff falling and making sound on start
-	await get_tree().create_timer(2).timeout
-	if is_instance_valid(loadscreen):
-		loadscreen.queue_free()   # Crashes if hit button too many times
-	emit_signal("loading_screen_removed")
-
-
-func change_scene_to_file(path) -> void:
-	get_tree().current_scene.queue_free()
-	get_tree().root.add_child(path)
-	get_tree().current_scene = path
-	
-	setup_loadscreen()
+	loading = false
+	#Only for debug menu
+	loading_screen_removed.emit()

--- a/globals/settings.gd
+++ b/globals/settings.gd
@@ -1,7 +1,9 @@
 class_name SettingsClass
 extends Node
 
-
+##If this is a singleton (autoloaded node), why is it also on a node inside a scene?
+#TODO: unify settings, possibly rework how they are in memory/file to something 
+#	less or not at all error prone. Current version will give corrupted data for some settings
 signal setting_added(setting_name)
 signal setting_removed(setting_name)
 signal setting_changed(setting_name, old_value, new_value)

--- a/scenes/characters/character_audio.gd
+++ b/scenes/characters/character_audio.gd
@@ -1,10 +1,21 @@
 class_name CharacterAudio
 extends Node3D
 
-
+# TODO: Overhaul the entire system so as not to have multiple objects with the same streams in-memory, 
+#       support multiple materials (ie for walking).
+#       Also, save the Audio node with the child nodes as a scene, so as to avoid the possibility 
+#       of human error when creating new characters
 # TODO: Eventually get working or ensure working different footstep sounds
-@onready var _footstep_sounds : Array = _stone_footstep_sounds   # Unsure if onready needed
-var _stone_footstep_sounds : Array = []
+@onready var _footstep_sounds : Array = _stone_footstep_sounds   # Unsure if onready needed ##Does not help to assign it an empty array
+# TODO: Either line 4, or have static links to files, like line 11-18
+var _stone_footstep_sounds : Array = [
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_1.wav"),
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_2.wav"),
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_3.wav"),
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_4.wav"),
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_5.wav"),
+	preload("res://resources/sounds/footsteps/stone_footsteps/footstep_6.wav")
+	]
 var _wood_footstep_sounds : Array = []
 var _carpet_footstep_sounds : Array = []
 var _water_footstep_sounds : Array = []
@@ -70,7 +81,7 @@ var last_speech_type   # Tracked to avoid interrupting self to say same type of 
 
 func _ready():
 	# Movement audio	
-	load_sounds("resources/sounds/footsteps/stone_footsteps", 3)
+	#load_sounds("resources/sounds/footsteps/stone_footsteps", 3)
 	#load_sounds("resources/sounds/footsteps/wood_footsteps", 4)
 	#load_sounds("resources/sounds/footsteps/water_footsteps", 5)
 	load_sounds("resources/sounds/footsteps/gravel_footsteps", 6)
@@ -97,9 +108,10 @@ func load_sounds(sound_dir, type : int) -> void:
 	if sound_dir.ends_with("/"):
 		sound_dir.erase(sound_dir.length() - 1, 1)
 
-	if sound_dir.begins_with("res://"):
+	if !sound_dir.begins_with("res://"):
 		sound_dir = "res://" + sound_dir
-
+	
+	
 	var snd_dir = DirAccess.open(sound_dir)
 	
 	if not is_instance_valid(snd_dir):
@@ -439,12 +451,21 @@ func _on_BT_Reload_Gun_character_reloaded():
 # Movement
 
 func play_footstep_sound(rate : float = 0.0, pitch : float = 1.0, volume : float = 0.0):
+	if(movement_audio.playing):
+		return
 	movement_audio.volume_db = rate
 	movement_audio.pitch_scale = pitch
-	movement_audio.volume_db = volume
-	if _footstep_sounds.size() > 0:
-		_footstep_sounds.shuffle()
-		movement_audio.stream = _footstep_sounds.front()
+	## Why is there a volume AND a rate? TODO: fix during overhaul
+	#movement_audio.volume_db = volume
+	## During the overhaul, have a proper way to give the material and 
+	#  select the audio stream array with a match statement
+	#if _footstep_sounds.size() > 0:
+		#_footstep_sounds.shuffle()
+		#movement_audio.stream = _footstep_sounds.front()
+		#movement_audio.play()
+	if _stone_footstep_sounds.size() > 0:
+		_stone_footstep_sounds.shuffle()
+		movement_audio.stream = _stone_footstep_sounds.front()
 		movement_audio.play()
 
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=7 format=3 uid="uid://d4addihtopap0"]
+[gd_scene load_steps=8 format=3 uid="uid://d4addihtopap0"]
 
 [ext_resource type="Script" path="res://scenes/game.gd" id="1"]
 [ext_resource type="Script" path="res://globals/settings.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://bg7aeaviu8ftd" path="res://scenes/characters/player/player.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://d1lbexonric4u" path="res://scenes/worlds/procedural_world/procedural_world.tscn" id="4"]
-[ext_resource type="PackedScene" path="res://scenes/ui/game_ui.tscn" id="5"]
+[ext_resource type="PackedScene" uid="uid://ojhqun7ijups" path="res://scenes/ui/game_ui.tscn" id="5"]
 [ext_resource type="Environment" uid="uid://bxgnfe0qgcrm" path="res://scenes/worlds/game_environment.tres" id="6"]
+[ext_resource type="PackedScene" uid="uid://d0h4ce7jlo0b0" path="res://scenes/ui/loadscreen/load_screen.tscn" id="7_4hehu"]
 
 [node name="Game" type="Node"]
 process_mode = 1
@@ -24,3 +25,6 @@ script = ExtResource("2")
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = ExtResource("6")
+
+[node name="Loading" parent="." instance=ExtResource("7_4hehu")]
+visible = false

--- a/scenes/objects/large_objects/large_object.gd
+++ b/scenes/objects/large_objects/large_object.gd
@@ -17,7 +17,7 @@ func _enter_tree():
 
 
 func _integrate_forces(state):
-	if !is_instance_valid(LoadScene.loadscreen):   # If it's at least a few seconds after level load
+	if !LoadScene.loading:   # If it's at least a few seconds after level load
 		if state.get_contact_count() > 0:
 			if state.get_contact_count() > oldCount and state.linear_velocity.length() > 0.4:
 				play_drop_sound(state.linear_velocity.length(), false)

--- a/scenes/objects/pickable_items/pickable_item.gd
+++ b/scenes/objects/pickable_items/pickable_item.gd
@@ -29,6 +29,7 @@ var item_drop_pitch_level = 10
 
 var has_thrown = false
 #var deceleration_factor = 0.9
+var can_play_sound : bool = false
 
 var initial_linear_velocity
 var is_soundplayer_ready = false
@@ -42,6 +43,8 @@ var is_soundplayer_ready = false
 
 
 func _enter_tree():
+	await get_tree().create_timer(2).timeout
+	can_play_sound = true
 	if not audio_player:
 		var drop_sound = AudioStreamPlayer3D.new()
 		drop_sound.name = "DropSound"
@@ -93,7 +96,7 @@ func play_throw_sound():
 
 
 func play_drop_sound(body):
-	if !is_instance_valid(LoadScene.loadscreen):   # If it's at least a few seconds after level load
+	if (!LoadScene.loading and can_play_sound):   # If it's at least a few seconds after level load
 		if self.item_drop_sound and self.audio_player and self.linear_velocity.length() > 0.2 and self.is_soundplayer_ready:
 			self.audio_player.stream = self.item_drop_sound
 			

--- a/scenes/ui/game_ui.gd
+++ b/scenes/ui/game_ui.gd
@@ -36,9 +36,8 @@ func on_gui_scale_changed(value):
 
 
 func _input(event: InputEvent) -> void:
-	if is_instance_valid(LoadScene.loadscreen):
-		if LoadScene.loadscreen.visible:
-			return
+	if LoadScene.loading:
+		return
 	if event.is_action_pressed("esc_menu") and not GameManager.is_player_dead:
 		match gui_state:
 			GUIState.HUD:

--- a/scenes/ui/loadscreen/load_screen.gd
+++ b/scenes/ui/loadscreen/load_screen.gd
@@ -1,35 +1,66 @@
 extends CanvasLayer
-
-
+class_name LoadScreen
+# TODO: stop making a generator everywhere, having a global one is more performant and uses less memory
+# TODO: when the level generator works, add this scene on top of the game scene and show + run it 
+#       whenever it's time to get the new level, waiting not for loading, but generation
 var random_num_gen = RandomNumberGenerator.new()
 var random_num
+const DEFAULT_PATH_TO_STARTUP = "res://scenes/ui/opening_screens.tscn"
+var loading_done : bool = false
+var next_scene_path : String = ""
+var next_scene : PackedScene
+var error
+@onready var color_rect = $ColorRect
+@onready var label = $Label
+@onready var quote = $Holder/Quote
+@onready var load_timer : Timer = $LoadTimer
 
-var is_loading = true
-var clicked = false   # User clicked after Click to Continue shown, but loadscreen still present until timeout
-
-@onready var color_rect = get_node("ColorRect")
-@onready var label = get_node("Label")
-@onready var quote = get_node("Holder/Quote")
+signal clicked
 
 
 func _input(event: InputEvent):
-	if !clicked:   # Without this, clicking many times will cause crash in load_scene
-		if (
-				(
-					(event is InputEventMouseButton and event.is_pressed())
-					or event.is_action_released("ui_accept") or event.is_action_released("ui_cancel")
-				)
-				and not is_loading
-		):
-#		var _error = get_tree().change_scene(LoadScene.next_scene)
-			LoadScene.remove_loadscreen()
-			clicked = true
+	if (event is InputEventMouseButton and event.is_pressed() and loading_done):
+		loading_done = false 
+		handle_external_settings()
+		fade_out()
+		await clicked
+		LoadScene.clear_data()
+		##For when changing to a different scene, so we spawned the load screen
+		# with the LoadScene.change_scene_to_file()
+		if(LoadScene.target_node == null):
+			if(next_scene != null): #Extra safety
+				LoadScene.clear_data()
+				get_tree().change_scene_to_packed(next_scene)
+		##For when loading an existing level and adding it to the world (not generating, but loading)
+		elif (LoadScene.target_node != null):
+			LoadScene.target_node.add_child(next_scene.instantiate())
+			LoadScene.clear_data()
+			#clear_data()
 
 
-func _ready():
-#	Input.mouse_mode = Input.MOUSE_MODE_HIDDEN
-	
+func start_loading():
+	#With the suggestion from line 3, this is not required anymore. 
+	#The randomize method is somewhat expensive to run, so running it 
+	#only once on the global one it should be much easier
 	random_num_gen.randomize()
+	show_message()
+	load_scene()
+	load_timer.start()
+
+
+func load_scene():
+	next_scene_path = LoadScene.next_scene
+	#TODO: remove next line once no longer required by other ui parts waiting for loads
+	if(next_scene_path.is_empty()):
+		get_tree().change_scene_to_file(DEFAULT_PATH_TO_STARTUP)
+		return
+	else:
+		error = ResourceLoader.load_threaded_request(next_scene_path)
+
+
+func show_message():
+	setup_loading_screen()
+	#Level 2, or 4 or whatever would be better as predefined constants
 	if GameManager.act > 4:
 		# late game
 		random_num = random_num_gen.randi_range(0, LoadQuotes.list3.size()-1)
@@ -43,11 +74,74 @@ func _ready():
 		random_num = random_num_gen.randi_range(0, LoadQuotes.list1.size()-1)
 		quote.text = LoadQuotes.list1[random_num]
 	
-	# Is here to hopefully ensure the quotes showup before the freeze on loading
-	await get_tree().create_timer(0.1).timeout   # To attempt to ensure lowend computers get something showing before it freezes
-	LoadScene.connect("scene_loaded", Callable(self, "on_scene_loaded"))
+	show()
+	#get_tree().paused = true
+	
+	
+func _on_load_timer_timeout():
+	#Every 0.5s, check if the next scene has loaded yet
+	var progress = []
+	match ResourceLoader.load_threaded_get_status(next_scene_path, progress):
+		ResourceLoader.ThreadLoadStatus.THREAD_LOAD_IN_PROGRESS: 
+			#This could be an update to something if required, like a progress bar, 
+			#or just showing the percentage
+			print("Still loading, " + str(progress[0]) + "% done")
+		ResourceLoader.ThreadLoadStatus.THREAD_LOAD_FAILED:
+			printerr("PANIC, can't load " + next_scene_path)
+			get_tree().change_scene_to_file(DEFAULT_PATH_TO_STARTUP)
+		ResourceLoader.ThreadLoadStatus.THREAD_LOAD_INVALID_RESOURCE:
+			printerr("PANIC, BAD or NO Resource " + next_scene_path)
+			get_tree().change_scene_to_file(DEFAULT_PATH_TO_STARTUP) 
+		ResourceLoader.ThreadLoadStatus.THREAD_LOAD_LOADED:
+			print("Good, loaded next scene! ")
+			load_timer.stop()
+			next_scene = ResourceLoader.load_threaded_get(next_scene_path)
+			finish_loading()
+	if !loading_done:
+		load_timer.start()
 
 
-func on_scene_loaded():
-	is_loading = false
-	$Label.text = "Click to Continue"
+func finish_loading():
+	loading_done = true
+	label.text = "Click to Continue"
+
+
+func clear_data():
+	loading_done = false
+	next_scene_path = ""
+	next_scene = null
+	LoadScene.clear_data()
+
+
+func setup_loading_screen():
+	label.text = "Loading..."
+	color_rect.modulate = Color.from_hsv(1,1,1,1)
+	LoadScene.loading = true
+	loading_done = false
+
+
+func handle_external_settings():
+	AudioSettings.internal_effects_volume = 0.0
+	
+	get_tree().create_tween()\
+		.tween_property(AudioSettings, "internal_effects_volume", 1.0, 5.0)\
+		.set_trans(Tween.TRANS_EXPO)\
+		.set_ease(Tween.EASE_IN)
+		
+	if GameManager.game != null and GameManager.game.player != null:
+		GameManager.game.player.player_controller.no_click_after_load_period = true
+		await get_tree().create_timer(1).timeout   # Possibly 0.5 better?
+		GameManager.game.player.player_controller.no_click_after_load_period = false
+
+
+func fade_out():
+	#hide the texts to show black screen
+	label.text = ""
+	quote.text = ""
+	color_rect.modulate = Color.from_hsv(1,1,1,1)
+	get_tree().paused = false
+	var tween = get_tree().create_tween()
+	tween.set_trans(Tween.TRANS_EXPO)
+	tween.tween_property(color_rect, "modulate", Color.from_hsv(1,1,1,0), 1)
+	await tween.finished
+	clicked.emit()

--- a/scenes/ui/loadscreen/load_screen.tscn
+++ b/scenes/ui/loadscreen/load_screen.tscn
@@ -97,7 +97,6 @@ cache/0/24/0/kerning_overrides/16/0 = Vector2(0, 0)
 cache/0/24/0/kerning_overrides/24/0 = Vector2(0, 0)
 
 [node name="Loading" type="CanvasLayer"]
-process_mode = 3
 layer = 2
 script = ExtResource("3")
 
@@ -125,6 +124,8 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="Quote" type="Label" parent="Holder"]
 layout_mode = 0
@@ -145,3 +146,9 @@ text = "“The sun went down with practiced bravado. Twilight crawled across the
 horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 3
+
+[node name="LoadTimer" type="Timer" parent="."]
+wait_time = 0.5
+one_shot = true
+
+[connection signal="timeout" from="LoadTimer" to="." method="_on_load_timer_timeout"]

--- a/scenes/ui/start_game_menu.gd
+++ b/scenes/ui/start_game_menu.gd
@@ -10,7 +10,8 @@ func _ready() -> void:
 	game = GAME_SCENE.instantiate()
 	%StartGameSettings.attach_settings(game.get_node("%LocalSettings"))
 	%SettingsUI.attach_settings(game.get_node("%LocalSettings"), false)
-	BackgroundMusic.volume_db = -10
+	var tween = get_tree().create_tween()
+	tween.tween_property(BackgroundMusic, "volume_db", -10, 0.3)
 
 
 func _input(event):
@@ -45,7 +46,13 @@ func _on_Timer_timeout():
 func _on_GameIntro_intro_done():
 	GameManager.is_player_dead = false
 	GameManager.act = 1
-	LoadScene.change_scene_to_file(game)
+	
+	##NOT IDEAL, manually adding/removing things like this,
+	# but changes to the changed scene and deletes current one.
+	# to be fixed with the settings unification
+	get_tree().root.add_child(game)
+	await get_tree().create_timer(0.5).timeout
+	get_tree().call_deferred("unload_current_scene")
 
 
 func _on_ReturnButton_pressed() -> void:

--- a/utils/debug_scenes/standalone_game_debug.gd
+++ b/utils/debug_scenes/standalone_game_debug.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 		get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (false) else Window.MODE_WINDOWED
 		get_window().size = _window_size
 		get_window().position = _window_position
-		LoadScene.setup_loadscreen()
+		#LoadScene.setup_loadscreen()
 		# warning-ignore:return_value_discarded
 		LoadScene.connect("loading_screen_removed", Callable(self, "_on_LoadScene_loading_screen_removed"))
 		GameManager.is_player_dead = false


### PR DESCRIPTION
Template for temporary audio fix (a full system rework would be beneficial, but this is faster).

Load Screen displayed when required and now works as intended. Previously, in built versions, scene did not change.

Add the build folder and  some more files to the gitignore, the .import helps have smaller commits, as the import settings shouldn't be manually done per every single object, but globally. Automatically generated files that number in the hundreds/thousands, now not taking space, making it hard to find out what a commit does.

Left some TODO's for future reference